### PR TITLE
CASMTRIAGE-1960: Fix typo causing the docker image to be misnamed

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -14,7 +14,7 @@ pipeline {
         NAME = "cray-ims"
         DESCRIPTION = "Cray Management Image Management Service"
         IS_STABLE = getBuildIsStable()
-        DOCKER_NAME = "cms-ims-service"
+        DOCKER_NAME = "cray-ims-service"
         RPM_NAME = "cray-ims-crayctldeploy-test"
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
     }


### PR DESCRIPTION
### Summary and Scope

A typo was causing the docker image to not match the image name in the manifest.  This restores the old docker name prior to github migration.

### Issues and Related PRs

* Resolves CASMTRIAGE-1960

### Testing

NA - build only

### Risks and Mitigations

None