### PR TITLE
CASMCMS-7434 Change to non-root user csm-1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ unittests:
 
 chart_setup:
 		mkdir -p ${CHART_PATH}/.packaged
-		printf "\nglobal:\n  appVersion: ${CHART_VERSION}" >> ${CHART_PATH}/${NAME}/values.yaml
 
 chart_package:
 		helm dep up ${CHART_PATH}/${NAME}

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The image can be run with the following command:
 
 ```bash
 $ docker run --rm --name ims-service \
-  -p 5000:80 \
+  -p 9000:9000 \
   -e "S3_ACCESS_KEY=minioadmin" \
   -e "S3_SECRET_KEY=minioadmin" \
   -e "S3_ENDPOINT=172.17.0.2:9000" \
@@ -185,14 +185,14 @@ $ docker run --rm --name ims-service \
   ims-service:dev
 ```
 
-This will start the IMS server on `http://localhost:5000`. An S3 instance is
+This will start the IMS server on `http://localhost:9000`. An S3 instance is
 required for the IMS server to do anything meaningful. See the [Configuration Options](#Configuration-Options)
 section for more information and further configuration possibilities.
 
 ```
-$ curl http://127.0.0.1:5000/images
+$ curl http://127.0.0.1:9000/images
 []
-$ curl http://127.0.0.1:5000/recipes
+$ curl http://127.0.0.1:9000/recipes
 []
 ```
 

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -23,7 +23,7 @@
 # Gunicorn settings for IMS
 import os
 
-bind = "0.0.0.0:80"
+bind = "0.0.0.0:9000"
 # workers = int(os.environ.get('WORKERS', 1))
 
 # Worker

--- a/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
+++ b/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ims-post-upgrade
+  namespace: {{ .Values.ims_config.cray_ims_service_namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-upgrade
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: ims-post-upgrade-hook1-container
+        image: "baseos/alpine:3.13"
+        command:
+          - bin/sh
+          - -c
+          - chown -Rv 65534:65534 /var/ims/data
+        volumeMounts:
+          - mountPath: /var/ims/data
+            name: cray-ims-data
+      volumes:
+        - name: cray-ims-data
+          persistentVolumeClaim:
+            claimName: cray-ims-data-claim

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -56,7 +56,7 @@ cray-service:
         repository: cray/cray-ims-service
       ports:
         - name: http
-          containerPort: 80
+          containerPort: 9000
       envFrom:
         - configMapRef:
             name: ims-config
@@ -94,7 +94,7 @@ cray-service:
           mountPath: /mnt/ims/v2/job_templates/customize
       livenessProbe:
         httpGet:
-          port: 80
+          port: 9000
           path: /healthz/live
         initialDelaySeconds: 5
         periodSeconds: 60
@@ -102,7 +102,7 @@ cray-service:
         failureThreshold: 3
       readinessProbe:
         httpGet:
-          port: 80
+          port: 9000
           path: /healthz/ready
         initialDelaySeconds: 5
         periodSeconds: 10


### PR DESCRIPTION
This PR makes the following changes:

- Reorganize the Dockerfile to establish a Python virtual environment and set the user to NOBODY. The python virtual environment enables pip and python to run as the NOBODY user.
- Fix the Makefile to not add 'appVersion' tag to the Chart values.yaml file
- Update the README.md file
- Update guinicorn & various other files to use port 9000 instead of port 80
- Add post upgrade helm hook to modify the ownership of existing IMS datafiles.

Tested on Mug