### PR TITLE
CASMCMS-7553 Do not allow multiple records to reference the same artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The following are required:
    ```
    $ docker pull minio/minio
    
-   $ docker run -p 9000:9000 -d minio/minio server /data
+   $ docker run -p 9000:9000,9001:9001 -d minio/minio server /data --console-address :9001
    941dbec66ecd9fe062a0fc99a2ac1e998e89abc72293d001dc4a484f7a9bc67a
    
    $ docker logs 941dbec66ecd9fe062a0fc99a2ac1e998e89abc72293d001dc4a484f7a9bc67a
@@ -162,6 +162,11 @@ The following are required:
       .NET:       https://docs.min.io/docs/dotnet-client-quickstart-guide
    Detected default credentials 'minioadmin:minioadmin', please change the credentials immediately using 'MINIO_ACCESS_KEY' and 'MINIO_SECRET_KEY'
    ```
+
+    NOTE: Using podman, the command to start minio would be similar to 
+    ```
+    $ podman run -p 9000:9000,9001:9001 --net cni-podman1 minio/minio server /data --console-address :9001
+    ```
 
 ## Building
 ```

--- a/generate_test_data
+++ b/generate_test_data
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+import datetime
+import json
+import os
+from io import BytesIO
+
+import boto3 as boto3
+import requests
+from botocore.exceptions import ClientError
+
+IMS_SERVICE_URL = os.environ.get("IMS_SERVICE_URL", "http://localhost:5000")
+
+S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "http://localhost:9000")
+S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", "minioadmin")
+S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY", "minioadmin")
+S3_SSL_VALIDATE = True if os.environ.get("S3_SSL_VALIDATE", "False").lower in ('yes', 'true', '1', 'on', 'y') else False
+
+ONE_MEGABYTE = 1024 * 1024
+
+RECIPES_BUCKET = os.environ.get('RECIPES_BUCKET', 'ims')
+BOOT_IMAGES_BUCKET = os.environ.get('BOOT_IMAGES_BUCKET', 'boot-images')
+
+s3 = boto3.resource(
+    service_name='s3',
+    verify=S3_SSL_VALIDATE,
+    endpoint_url=S3_ENDPOINT,
+    aws_access_key_id=S3_ACCESS_KEY,
+    aws_secret_access_key=S3_SECRET_KEY,
+)
+
+
+def generate_test_file(bucket_name, key, artifact_type, size=ONE_MEGABYTE):
+    try:
+        bucket = s3.Bucket(bucket_name)
+        result = bucket.put_object(Key=key, Body=BytesIO(os.urandom(size)))
+
+        return {
+            'link': {
+                'path': f's3://{bucket_name}/{key}',
+                'etag': result.e_tag.strip('\"'),
+                'type': 's3'
+            },
+            'type': artifact_type
+        }
+    except ClientError as err:
+        raise
+
+
+def generate_image_manifest(image_id, artifacts):
+    """
+    Utility function to create an image manifest from a set of artifacts.
+    """
+    image_manifest_version_1_0 = '1.0'
+
+    manifest_data = {
+        'version': image_manifest_version_1_0,
+        'created': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        'artifacts': artifacts
+    }
+
+    key = f'{image_id}/manifest.json'
+    bucket = s3.Bucket(BOOT_IMAGES_BUCKET)
+    result = bucket.put_object(Key=key, Body=BytesIO(json.dumps(manifest_data).encode('utf-8')))
+
+    return {
+        'path': f's3://{BOOT_IMAGES_BUCKET}/{key}',
+        'etag': result.e_tag.strip('\"'),
+        'type': 's3'
+    }
+
+
+def generate_ims_image():
+    result = requests.post(f'{IMS_SERVICE_URL}/images', json={'name': 'test'})
+    result.raise_for_status()
+    image = result.json()
+
+    artifacts = []
+    for artifact_name, artifact_type in [('rootfs', 'application/vnd.cray.image.rootfs.squashfs'),
+                                         ('initrd', 'application/vnd.cray.image.initrd'),
+                                         ('kernel', 'application/vnd.cray.image.kernel')]:
+        artifacts.append(
+            generate_test_file(BOOT_IMAGES_BUCKET, f'{image["id"]}/{artifact_name}', artifact_type)
+        )
+
+    manifest_link = generate_image_manifest(image['id'], artifacts)
+
+    result = requests.patch(f'{IMS_SERVICE_URL}/images/{image["id"]}', json={'link': manifest_link})
+    result.raise_for_status()
+    return result.json()
+
+
+def generate_ims_recipe():
+    result = requests.post(f'{IMS_SERVICE_URL}/recipes',
+                           json={'name': 'test', 'recipe_type': 'kiwi-ng', 'linux_distribution': 'sles15'})
+    result.raise_for_status()
+    recipe = result.json()
+
+    recipe_tgz = generate_test_file(RECIPES_BUCKET, f'recipes/{recipe["id"]}/recipe.tgz',
+                                    'application/vnd.cray.recipe.tgz')
+
+    result = requests.patch(f'{IMS_SERVICE_URL}/recipes/{recipe["id"]}', json={'link': recipe_tgz['link']})
+    result.raise_for_status()
+    return result.json()
+
+
+def main():
+    from pprint import pprint
+    print("Recipe:")
+    pprint(generate_ims_recipe())
+    print("Image:")
+    pprint(generate_ims_image())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server/ims_exceptions.py
+++ b/src/server/ims_exceptions.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+class ImsBaseException(Exception):
+    pass
+
+
+class ImsArtifactValidationException(ImsBaseException):
+    pass
+
+
+class ImsReadManifestJsonException(ImsBaseException):
+    pass
+
+class ImsSoftUndeleteArtifactException(ImsBaseException):
+    pass

--- a/src/server/v2/resources/images.py
+++ b/src/server/v2/resources/images.py
@@ -30,7 +30,7 @@ from flask_restful import Resource
 
 from src.server.errors import problemify, generate_missing_input_response, generate_data_validation_failure, \
     generate_resource_not_found_response, generate_patch_conflict
-from src.server.helper import validate_artifact, delete_artifact, read_manifest_json, get_log_id, \
+from src.server.helper import delete_artifact, read_manifest_json, get_log_id, \
     validate_image_manifest, IMAGE_MANIFEST_ARTIFACTS
 from src.server.models.images import V2ImageRecordInputSchema, V2ImageRecordSchema, V2ImageRecordPatchSchema
 

--- a/src/server/v2/resources/recipes.py
+++ b/src/server/v2/resources/recipes.py
@@ -27,9 +27,10 @@ import http.client
 from flask import jsonify, request, current_app
 from flask_restful import Resource
 
+from src.server.ims_exceptions import ImsArtifactValidationException
 from src.server.errors import problemify, generate_missing_input_response, generate_data_validation_failure, \
      generate_resource_not_found_response, generate_patch_conflict
-from src.server.helper import validate_artifact, delete_artifact, get_log_id, ARTIFACT_LINK
+from src.server.helper import validate_artifact, delete_artifact, get_log_id, ARTIFACT_LINK, verify_recipe_link_unique
 from src.server.models.recipes import V2RecipeRecordInputSchema, V2RecipeRecordSchema, V2RecipeRecordPatchSchema
 
 recipe_user_input_schema = V2RecipeRecordInputSchema()
@@ -77,10 +78,15 @@ class V2RecipeCollection(Resource):
         new_recipe = recipe_schema.load(json_data)
 
         if new_recipe.link:
-            _, problem = validate_artifact(new_recipe.link)
+            problem = verify_recipe_link_unique(new_recipe.link)
             if problem:
-                current_app.logger.info("%s Could not validate link artifact or artifact doesn't exist", log_id)
+                current_app.logger.info("Link value being set is not unique")
                 return problem
+
+            try:
+                validate_artifact(new_recipe.link)
+            except ImsArtifactValidationException as exc:
+                return problemify(status=http.client.UNPROCESSABLE_ENTITY, detail=str(exc))
 
         # Save to datastore
         current_app.data['recipes'][str(new_recipe.id)] = new_recipe
@@ -192,10 +198,15 @@ class V2RecipeResource(Resource):
                     current_app.logger.info("%s recipe record cannot be patched since it already has link info", log_id)
                     return generate_patch_conflict()
                 else:
-                    _, problem = validate_artifact(value)
+                    problem = verify_recipe_link_unique(value)
                     if problem:
-                        current_app.logger.info("%s Could not validate link artifact or artifact doesn't exist", log_id)
+                        current_app.logger.info("Link value being set is not unique")
                         return problem
+
+                    try:
+                        validate_artifact(value)
+                    except ImsArtifactValidationException as exc:
+                        return problemify(status=http.client.UNPROCESSABLE_ENTITY, detail=str(exc))
             else:
                 current_app.logger.info("%s Not able to patch record field {} with value {}", log_id, key, value)
                 return generate_data_validation_failure(errors=[])

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -38,6 +38,7 @@ from flask_restful import Resource
 from kubernetes import client, config, utils
 from kubernetes.client.rest import ApiException
 
+from src.server.ims_exceptions import ImsArtifactValidationException
 from src.server.errors import problemify, generate_missing_input_response, generate_data_validation_failure, \
     generate_resource_not_found_response
 from src.server.helper import validate_artifact, get_log_id, get_download_url, read_manifest_json, \
@@ -363,9 +364,10 @@ class V3JobCollection(V3BaseJobResource):
         if problem:
             return None, problem
 
-        md5sum, problem = validate_artifact(artifact_record.link)
-        if problem:
-            return None, problem
+        try:
+            md5sum = validate_artifact(artifact_record.link)
+        except ImsArtifactValidationException as exc:
+            return problemify(status=http.client.UNPROCESSABLE_ENTITY, detail=str(exc))
 
         return {'artifact': artifact_record, 'md5sum': md5sum}, None
 
@@ -482,9 +484,10 @@ class V3JobCollection(V3BaseJobResource):
             if "md5" in rootfs_artifact and rootfs_artifact["md5"]:
                 manifest_rootfs_md5sum = rootfs_artifact["md5"]
 
-            s3obj_rootfs_md5sum, problem = validate_artifact(rootfs_artifact[ARTIFACT_LINK])
-            if problem:
-                return None, problem
+            try:
+                s3obj_rootfs_md5sum = validate_artifact(rootfs_artifact[ARTIFACT_LINK])
+            except ImsArtifactValidationException as exc:
+                return problemify(status=http.client.UNPROCESSABLE_ENTITY, detail=str(exc))
 
             if manifest_rootfs_md5sum and s3obj_rootfs_md5sum and manifest_rootfs_md5sum != s3obj_rootfs_md5sum:
                 current_app.logger.info("%s The rootfs md5sum from the manifest.json does not match the md5sum "


### PR DESCRIPTION
### Summary and Scope

This change fixes IMS to properly handle an error condition which previously could cause IMS's database to become corrupt. Essentially, IMS was allowing multiple records to reference the same S3 link value (both for recipes and images). This was not an issue, until those records were deleted. Due to IMS's soft-delete logic, IMS would properly rename the S3 artifact when the first record was deleted. However, when the record with the duplicate S3 link was deleted, the link value would become corrupted. 

The fix was to change the error handling and add additional exception handling to raise the errors to the proper level where they could be passed on to the user instead of being swallowed by IMS. IMS will now 'handle' the case of deleting a record with a duplicate link, and should no longer cause the IMS database to become corrupted. Both the delete and undelete cases have been fixed. 

In addition, IMS will now perform a linear search of existing records when setting the link value of a recipe or image record. This will prevent new records from being created that have duplicate links. 

### Issues and Related PRs

* Resolves CASMCMS-7553

### Testing

Tested on:
* Significant testing was performed locally on my development laptop
* Mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? No
Was an Upgrade tested?    Yes
Was a Downgrade tested?   Yes

### Risks and Mitigations

None

## Checklist

- [x] Ready for Merge