### PR TITLE
CASMCMS-7703 Update jobs access pool to be customer-management

### DIFF
--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -10,8 +10,10 @@ data:
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
   DEFAULT_IMS_IMAGE_SIZE: "10"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
-  SHASTA_DOMAIN: "{{ .Values.customer_access.shasta_domain }}"
-  CUSTOMER_ACCESS_POOL: "{{ .Values.customer_access.access_pool }}"
+
+  JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN: "{{ .Values.customer_access.shasta_domain }}"
+  JOB_CUSTOMER_ACCESS_SUBNET_NAME: "{{ .Values.customer_access.subnet_name }}"
+  JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL: "{{ .Values.customer_access.access_pool }}"
 
   S3_IMS_BUCKET: "{{ .Values.s3.ims_bucket }}"
   S3_BOOT_IMAGES_BUCKET: "{{ .Values.s3.boot_images_bucket }}"

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -58,7 +58,8 @@ keycloak:
 
 customer_access:
   shasta_domain: "shasta.local"
-  access_pool: "customer-access"
+  access_pool: "customer-management"
+  subnet_name: "cmn"
 
 cray-service:
   type: Deployment

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -74,8 +74,12 @@ class V3BaseJobResource(Resource):
         self.api_gateway_hostname = os.environ.get("API_GATEWAY_HOSTNAME", "api-gw-service-nmn.local")
         self.default_ims_job_namespace = os.environ.get("DEFAULT_IMS_JOB_NAMESPACE", "ims")
 
-        self.shasta_domain = os.environ.get("SHASTA_DOMAIN", "shasta.local")
-        self.customer_access_pool = os.environ.get("CUSTOMER_ACCESS_POOL", "customer-access")
+        self.job_customer_access_network_access_pool = os.environ.get(
+            "JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL", "customer-management")
+
+        # {job.id}.ims.{job_customer_access_subnet_name}.{self.job_customer_access_network_domain}"
+        self.job_customer_access_subnet_name = os.environ.get("JOB_CUSTOMER_ACCESS_SUBNET_NAME", "cmn")
+        self.job_customer_access_network_domain = os.environ.get("JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN", "shasta.local")
 
     def _create_namespaced_destination_rule(self, namespace):
         """ Helper routine to create a partial function to create a new ISTIO destination rule. """
@@ -607,7 +611,7 @@ class V3JobCollection(V3BaseJobResource):
             current_app.logger.info("%s Could not get download url for artifact", log_id)
             return problem
 
-        external_dns_hostname = "{}.ims.{}".format(str(new_job.id).lower(), self.shasta_domain)
+        external_dns_hostname = f"{str(new_job.id).lower()}.ims.{self.job_customer_access_subnet_name}.{self.job_customer_access_network_domain}"
 
         template_params = {
             "id": str(new_job.id).lower(),
@@ -622,7 +626,7 @@ class V3JobCollection(V3BaseJobResource):
             "kernel_filename": new_job.kernel_file_name,
             "initrd_filename": new_job.initrd_file_name,
             "kernel_parameters_filename": new_job.kernel_parameters_file_name,
-            "address_pool": self.customer_access_pool,
+            "address_pool": self.job_customer_access_network_access_pool,
             "hostname": external_dns_hostname,
             "namespace": self.default_ims_job_namespace,
             "s3_bucket": current_app.config["S3_BOOT_IMAGES_BUCKET"]

--- a/tests/v2/test_v2_jobs.py
+++ b/tests/v2/test_v2_jobs.py
@@ -456,7 +456,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                          r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z')
         self.assertIsNotNone(response_data['ssh_containers'], 'ssh_containers not null')
 
-        external_host_name = "{}.ims.shasta.local".format(response_data['id'])
+        external_host_name = "{}.ims.cmn.shasta.local".format(response_data['id'])
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['host'],
                          external_host_name, 'SSH Container host value did not match expected value')
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['port'], 22,
@@ -709,7 +709,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
         self.assertEqual(response_data['ssh_containers'][0]['jail'], ssh_container_jail,
                          'SSH Container jail value did not match')
 
-        external_host_name = "{}.ims.shasta.local".format(response_data['id'])
+        external_host_name = "{}.ims.cmn.shasta.local".format(response_data['id'])
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['host'],
                          external_host_name, 'SSH Container host value did not match expected value')
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['port'], 22,

--- a/tests/v3/test_v3_jobs.py
+++ b/tests/v3/test_v3_jobs.py
@@ -456,7 +456,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                          r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z')
         self.assertIsNotNone(response_data['ssh_containers'], 'ssh_containers not null')
 
-        external_host_name = "{}.ims.shasta.local".format(response_data['id'])
+        external_host_name = "{}.ims.cmn.shasta.local".format(response_data['id'])
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['host'],
                          external_host_name, 'SSH Container host value did not match expected value')
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['port'], 22,
@@ -709,7 +709,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.assertEqual(response_data['ssh_containers'][0]['jail'], ssh_container_jail,
                          'SSH Container jail value did not match')
 
-        external_host_name = "{}.ims.shasta.local".format(response_data['id'])
+        external_host_name = "{}.ims.cmn.shasta.local".format(response_data['id'])
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['host'],
                          external_host_name, 'SSH Container host value did not match expected value')
         self.assertEqual(response_data['ssh_containers'][0]['connection_info']['customer_access']['port'], 22,


### PR DESCRIPTION
## Summary and Scope

Update the default access pool for IMS jobs to be `customer-management` from `customer-access`. This change is in support of the work for the bifurcated-CAN and moves the IMS jobs to the management network. Essentially, this means that IMS Job pods are accessible to administrators only via the customer-management network. According to @johren-hpe this should not change any pod to pod communication, so it should not affect CFS communicating with IMS jobs. 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7703](https://connect.us.cray.com/jira/browse/CASMCMS-7703)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `wasp`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Installed new IMS helm chart and associated images. Ran an IMS customization job and saw that the ssh shell was now available on the customer-management network

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? no
- Were continuous integration tests run? If not, why? no
- Was upgrade tested? If not, why? no
- Was downgrade tested? If not, why? no
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

