### PR TITLE
Refactor alpine image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # (MIT License)
 
 # Create 'base' image target
-FROM artifactory.algol60.net/docker.io/alpine:3.13 as base
+FROM artifactory.algol60.net/docker.io/library/alpine:3.13 as base
 WORKDIR /app
 RUN mkdir -p /var/ims/data /app /results && \
     chown -Rv 65534:65534 /var/ims/data /app /results

--- a/kubernetes/cray-ims/Chart.yaml
+++ b/kubernetes/cray-ims/Chart.yaml
@@ -30,5 +30,5 @@ annotations:
     - name: cray-ims-sshd
       image: artifactory.algol60.net/csm-docker/stable/cray-ims-sshd:3.4.5
     - name: alpine
-      image: artifactory.algol60.net/docker.io/alpine:latest
+      image: alpine:latest
   artifacthub.io/license: MIT

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -46,7 +46,8 @@ data:
           initContainers:
           # Step 1: Set ownership of volume mounts
           - name: set-ownership
-            image: artifactory.algol60.net/docker.io/alpine:latest
+            image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
+            imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
             command: ["/bin/sh"]
             args:
             - -c

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -46,7 +46,8 @@ data:
           initContainers:
           # Step 1: Set ownership of volume mounts
           - name: set-ownership
-            image: artifactory.algol60.net/docker.io/alpine:latest
+            image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
+            imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
             command: ["/bin/sh"]
             args:
             - -c

--- a/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
+++ b/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
@@ -13,7 +13,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: ims-post-upgrade-hook1-container
-        image: "artifactory.algol60.net/docker.io/alpine:latest"
+        image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
+        imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
         command:
           - bin/sh
           - -c

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -15,6 +15,12 @@ s3:
   connect_timeout: "60"
   read_timeout: "60"
 
+alpine:
+  image:
+    repository: alpine
+    tag: latest
+    pullPolicy: IfNotPresent
+
 ims_config:
   cray_ims_job_namespace: "ims"
   cray_ims_service_namespace: "services"


### PR DESCRIPTION
Add `alpine.image` settings to values.yaml in order to enable customization.

Change default alpine reference from `artifactory.algol60.net/docker.io/alpine:latest` to `alpine:latest`. Chart defaults should reference upstream locations instead of registry mirrors.

Supplements [CASMCMS-7618](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7618). Required to resolve [CASM-2670](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2670).