### PR TITLE
CASMCMS-7722 Roll back vol ownership changes

### DIFF
--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -44,29 +44,7 @@ data:
         spec:
           restartPolicy: Never  # Don't ever restart this job
           initContainers:
-          # Step 1: Set ownership of volume mounts
-          - name: set-ownership
-            image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
-            imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
-            command: ["/bin/sh"]
-            args:
-            - -c
-            - >-
-              set -x &&
-              chown -R 65534:65534 /mnt/recipe &&
-              chown -R 65534:65534 /mnt/ca-rpm &&
-              chown -R 65534:65534 /etc/cray/ims &&
-              chown -R 65534:65534 /mnt/image
-            volumeMounts:
-            - name: recipe-vol
-              mountPath: /mnt/recipe
-            - name: ca-rpm-vol
-              mountPath: /mnt/ca-rpm
-            - name: ims-config-vol
-              mountPath: /etc/cray/ims
-            - name: image-vol
-              mountPath: /mnt/image
-          # Step 2: Download and extract the image recipe archive
+          # Step 1: Download and extract the image recipe archive
           - image: {{ .Values.cray_ims_utils.image.repository }}:{{ .Values.cray_ims_utils.image.tag }}
             imagePullPolicy: {{ .Values.cray_ims_utils.image.imagePullPolicy }}
             name: fetch-recipe
@@ -101,7 +79,7 @@ data:
               limits:
                 memory: "$limit_gb"
                 cpu: "8"
-          # Step 3: Wait for Repos
+          # Step 2: Wait for Repos
           - image: {{ .Values.cray_ims_utils.image.repository }}:{{ .Values.cray_ims_utils.image.tag }}
             imagePullPolicy: {{ .Values.cray_ims_utils.image.imagePullPolicy }}
             name: wait-for-repos
@@ -132,7 +110,7 @@ data:
               limits:
                 memory: "$limit_gb"
                 cpu: "8"
-          # Step 4: Build a RPM containing the Cray Root CA certificate
+          # Step 3: Build a RPM containing the Cray Root CA certificate
           - image: {{ .Values.cray_ims_utils.image.repository }}:{{ .Values.cray_ims_utils.image.tag }}
             imagePullPolicy: {{ .Values.cray_ims_utils.image.imagePullPolicy }}
             name: build-ca-rpm
@@ -165,7 +143,7 @@ data:
               limits:
                 memory: "$limit_gb"
                 cpu: "8"
-          # Step 5: Build the image
+          # Step 4: Build the image
           - image: {{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}
             imagePullPolicy: {{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.imagePullPolicy }}
             name: build-image

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -44,23 +44,7 @@ data:
         spec:
           restartPolicy: Never  # Don't ever restart this job
           initContainers:
-          # Step 1: Set ownership of volume mounts
-          - name: set-ownership
-            image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
-            imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
-            command: ["/bin/sh"]
-            args:
-            - -c
-            - >-
-              set -x &&
-              chown -R 65534:65534 /etc/cray/ims &&
-              chown -R 65534:65534 /mnt/image
-            volumeMounts:
-            - name: ims-config-vol
-              mountPath: /etc/cray/ims
-            - name: image-vol
-              mountPath: /mnt/image
-          # Step 2: Download and extract the image root filesystem
+          # Step 1: Download and extract the image root filesystem
           - image: {{ .Values.cray_ims_utils.image.repository }}:{{ .Values.cray_ims_utils.image.tag }}
             imagePullPolicy: {{ .Values.cray_ims_utils.image.imagePullPolicy }}
             name: prepare


### PR DESCRIPTION
## Summary and Scope

After testing it has been determined that the ims-utils container must run as the root user. This is due to several factors, but all relate to the fact that ims-utils must be able to read and modify the image root being created/customized. For instance, ims-utils must be able to add the root-ca certificate to the image root's /etc/cray/ca directory. Running as the nobody user, the ims-utils container does not have the permissions to do that. Additionally, ims-utils must be able to run the squashfs tool to archive the image root. Again, this cannot be done as the nobody user.

This ims-service PR changes the ims job configmaps to remove changing the ownership of various volumes. 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7722](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7722)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<hela>`
  * Local development environment
  * Virtual Shasta

### Test description:

Modified the configmaps on hela and verified that IMS was able to successfully run both create and customize jobs. For customize jobs, both jailed and unjailed configurations were tested. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
