### PR TITLE
CASMCMS-7728: Use placeholder version strings that are unlikely to collide with actual version strings

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -127,7 +127,7 @@ info:
       The original image is still intact.  A user may want to install additional software, 
       install licenses, change the timezone, add mount points, etc.
     
-  version: "0.0.0"
+  version: "0.0.0-imsserv"
   title: Image Management Service
   license:
     name: Hewlett Packard Enterprise Development LP

--- a/kubernetes/cray-ims/Chart.yaml
+++ b/kubernetes/cray-ims/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ims
-version: 0.0.0
+version: 0.0.0-imsserv
 description: Kubernetes resources for cray-ims
 keywords:
 - Image Management Service
@@ -18,17 +18,17 @@ dependencies:
 maintainers:
 - name: ecozzi-hpe
   email: eric.cozzi@hpe.com
-appVersion: 0.0.0
+appVersion: 0.0.0-imsserv
 annotations:
   artifacthub.io/images: |
     - name: cray-ims-service
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-service:0.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-service:0.0.0-imsserv
     - name: cray-ims-utils
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-utils:1.2.3
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-utils:0.0.0-imsutils
     - name: cray-ims-kiwi-ng-opensuse-x86_64-builder
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-kiwi-ng-opensuse-x86_64-builder:2.3.4
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-kiwi-ng-opensuse-x86_64-builder:0.0.0-imskiwi
     - name: cray-ims-sshd
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-sshd:3.4.5
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-sshd:0.0.0-imssshd
     - name: alpine
       image: alpine:latest
   artifacthub.io/license: MIT

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -28,19 +28,19 @@ ims_config:
 cray_ims_utils:
   image:
     repository: "artifactory.algol60.net/csm-docker/stable/cray-ims-utils"
-    tag: "1.2.3"
+    tag: "0.0.0-imsutils"
     imagePullPolicy: IfNotPresent
 
 cray_ims_kiwi_ng_opensuse_x86_64_builder:
   image:
     repository: "artifactory.algol60.net/csm-docker/stable/cray-ims-kiwi-ng-opensuse-x86_64-builder"
-    tag: "2.3.4"
+    tag: "0.0.0-imskiwi"
     imagePullPolicy: IfNotPresent
 
 cray_ims_sshd:
   image:
     repository: "artifactory.algol60.net/csm-docker/stable/cray-ims-sshd"
-    tag: "3.4.5"
+    tag: "0.0.0-imssshd"
     imagePullPolicy: IfNotPresent
 
 cray_ims_packer_opensuse_x86_64_builder:

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -15,21 +15,21 @@
 #sourcefile: v2.txt
 #targetfile: 1/2/3.txt
 
-tag: 0.0.0
+tag: 0.0.0-imsserv
 targetfile: kubernetes/cray-ims/Chart.yaml
 targetfile: api/openapi.yaml
 
 sourcefile: cray-ims-utils.version
-tag: 1.2.3
+tag: 0.0.0-imsutils
 targetfile: kubernetes/cray-ims/Chart.yaml
 targetfile: kubernetes/cray-ims/values.yaml
 
 sourcefile: cray-ims-kiwi-ng-opensuse-x86_64-builder.version
-tag: 2.3.4
+tag: 0.0.0-imskiwi
 targetfile: kubernetes/cray-ims/Chart.yaml
 targetfile: kubernetes/cray-ims/values.yaml
 
 sourcefile: cray-ims-sshd.version
-tag: 3.4.5
+tag: 0.0.0-imssshd
 targetfile: kubernetes/cray-ims/Chart.yaml
 targetfile: kubernetes/cray-ims/values.yaml


### PR DESCRIPTION
## Summary and Scope

Zach Crisler noticed that the version tagging in the latest ims chart was messed up, Specifically, the version of ims-sshd had been used at the appVersion for ims itself. The underlying cause of this is because some of the version tags in update_versions.conf were ones that one might expect to find in the target files in other contexts. In this case, ims-sshd had a version tag of 3.4.5 specified. So when we tried to build that version of IMS, the update_versions script happily replaced that version with the version of ims-sshd.

This PR just replaces the possibly ambiguous version tags with ones that are extremely unlikely to show up otherwise. I followed the pattern of **0.0.0-label** that I saw used in a number of our other repos.

In theory I could put anything in this PR and it would correct the immediate problem, since bumping the version beyond 3.4.5 would avoid the issue being reported. But it is dangerous to retain the current version tags because it's quite possible we would introduce strings like 1.2.3 or 2.3.4 into these files not intending them to be version tags. 

This PR makes no functional changes to IMS. It just corrects the immediate problem reported by Zach and makes it very unlikely that we will see this problem in the future.

## Issues and Related PRs

None.

## Testing

No testing done other than verifying that the build uses the correct versions in the resulting chart, thus correcting the error being reported.

## Risks and Mitigations

Very low risk. No change to IMS itself is being made.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

