### PR TITLE
CASMINST-4084 - remove openapi-generator-cli docker image layer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Cray Image Management Service Dockerfile
-## Copyright 2018, 2021 Hewlett Packard Enterprise Development LP
+## Copyright 2018, 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -61,11 +61,13 @@ ARG FORCE_TESTS=null
 CMD [ "./docker_test_entry.sh" ]
 
 # Run openapi validation on openapi.yaml
-FROM arti.dev.cray.com/third-party-docker-stable-local/openapitools/openapi-generator-cli:v5.1.0 as openapi-validator
-RUN mkdir /tmp/api
-COPY api/openapi.yaml /tmp/api/
-ARG FORCE_OPENAPI_VALIDATION_CHECK=null
-RUN docker-entrypoint.sh validate -i /tmp/api/openapi.yaml || true
+# NOTE: at this time the openapi-generator-cli base image has CVE vulnerabilities
+# that we can't resolve.  Uncomment the below to use for testing and validation.
+# FROM arti.dev.cray.com/third-party-docker-stable-local/openapitools/openapi-generator-cli:v5.1.0 as openapi-validator
+# RUN mkdir /tmp/api
+# COPY api/openapi.yaml /tmp/api/
+# ARG FORCE_OPENAPI_VALIDATION_CHECK=null
+# RUN docker-entrypoint.sh validate -i /tmp/api/openapi.yaml || true
 
 # Run code style checkers
 FROM testing as codestyle

--- a/git_info.conf
+++ b/git_info.conf
@@ -33,4 +33,4 @@ specfile: cray-ims-crayctldeploy-test.spec
 # insert this line:
 # COPY gitInfo.txt gitInfo.txt
 
-dockerfile: Dockerfile base openapi-validator
+dockerfile: Dockerfile base


### PR DESCRIPTION
NOTE: may not be needed...

## Summary and Scope

The base image that openapi-generator-cli uses has CVE vulnerabilities and we are unable to update the image with patches to resolve them.  The ims project only uses this as a test/validation step, so I just removed that layer from the Dockerfile build.  It left it in the file but commented out, so developers can uncomment it and run checks when needed, but it will not ship in the release version of the image.

## Issues and Related PRs
* Resolves [CASMINST-4084](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4084)

## Testing
### Tested on:
  * Local development environment

### Test description:

Locally tested the new image with snyk to insure vulnerabilities are resolved.  There is no change to the functional portion of the image, just removing a testing layer that is not used in the final image so not re-testing on a real system.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be very low risk as it is just removing an intermediate docker layer that is not used in the final image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

