### PR TITLE
CSAMCMS-7970 - update dev.cray.com addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Build valid unstable charts
+- CASMCMS-7970 - update dev.cray.com addressess.
 
 ### Removed
 - Stopped building nonfunctional, outdated test RPM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Build valid unstable charts
 - CASMCMS-7970 - update dev.cray.com addressess.
+- CASMCMS-8015 - increase the default ims job size to handle larger images.
 
 ### Removed
 - Stopped building nonfunctional, outdated test RPM.

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,7 @@ ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN PIP_INDEX_URL=https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple \
-    PIP_TRUSTED_HOST=arti.dev.cray.com \
-    pip3 install --no-cache-dir -U pip && \
+RUN pip3 install --no-cache-dir -U pip && \
     pip3 install --no-cache-dir -U wheel && \
     pip3 install --no-cache-dir -r requirements.txt
 
@@ -63,7 +61,7 @@ ARG FORCE_TESTS=null
 CMD [ "./docker_test_entry.sh" ]
 
 # Run openapi validation on openapi.yaml
-FROM arti.dev.cray.com/third-party-docker-stable-local/openapitools/openapi-generator-cli:v5.1.0 as openapi-validator
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v5.1.0 as openapi-validator
 RUN mkdir /tmp/api
 COPY api/openapi.yaml /tmp/api/
 ARG FORCE_OPENAPI_VALIDATION_CHECK=null

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2296,8 +2296,8 @@ components:
           type: string
           readOnly: true
         build_env_size:
-          description: Size (in Gb) to allocate for the image root. Default = 10
-          example: 10
+          description: Size (in Gb) to allocate for the image root. Default = 15
+          example: 15
           type: integer
           minimum: 1
         kubernetes_namespace:

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -31,7 +31,7 @@ metadata:
 data:
   API_GATEWAY_HOSTNAME: "{{ .Values.api_gw.api_gw_service_name }}.{{ .Values.api_gw.api_gw_service_namespace }}.svc.cluster.local"
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
-  DEFAULT_IMS_IMAGE_SIZE: "10"
+  DEFAULT_IMS_IMAGE_SIZE: "15"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
 
   JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN: "{{ .Values.customer_access.shasta_domain }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# Only use Cray-procured packages
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 -c constraints.txt
 
 # Application requirements for cms-ims

--- a/src/server/models/jobs.py
+++ b/src/server/models/jobs.py
@@ -58,7 +58,7 @@ STATUS_TYPES = (JOB_STATUS_CREATING,
 
 DEFAULT_INITRD_FILE_NAME = 'initrd'
 DEFAULT_KERNEL_FILE_NAME = 'vmlinuz'
-DEFAULT_IMAGE_SIZE = os.environ.get("DEFAULT_IMS_IMAGE_SIZE", 10)
+DEFAULT_IMAGE_SIZE = os.environ.get("DEFAULT_IMS_IMAGE_SIZE", 15)
 DEFAULT_KERNEL_PARAMETERS_FILE_NAME = 'kernel-parameters'
 
 
@@ -122,7 +122,7 @@ class V2JobRecordInputSchema(Schema):
                                                          error="image_root_archive_name field must not be blank"))
     enable_debug = fields.Boolean(default=False,
                                   Description="Whether to enable debugging of the job")
-    build_env_size = fields.Integer(Default=10,
+    build_env_size = fields.Integer(Default=15,
                                     Description="approximate disk size in GiB to reserve for the image build"
                                                 "environment (usually 2x final image size)",
                                     validate=Range(min=1, error="build_env_size must be greater than or equal to 1"))

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,11 +1,11 @@
 image: cray-ims-utils
     major: 2
-    minor: 7
+    minor: 8
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
-    minor: 3
+    minor: 4
 
 image: cray-ims-sshd
     major: 1
-    minor: 5
+    minor: 6


### PR DESCRIPTION
## Summary and Scope

This picks up the changes in ims-utils, ims-sshd, ims-python-helper, and cray-ims-kiwi-ng-opensuse-x86_64-builder for updating the dev.cray.com addresses.  It also increases the default memory size for the ims jobs created since images are getting bigger and people are running into issues running out of space.

## Issues and Related PRs
* Resolves [CASMCMS-7970](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7970)
* Resolves [CASMCMS-8015](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8015)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I upgraded to the new version via helm, then ran both an image customization job, as well as a recipe build job.  There were problems with the recipe build, but other people were seeing the same nexus access issues the build job was running into so it looks like ims is doing everything it is supposed to.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a low risk change as it is mostly just updating the addresses of servers in the dev.cray.com domain that have moved and increasing the default job memory size.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

