### PR TITLE
CASMTRIAGE-4091 - make gunicorn worker timeout configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMTRIAGE-4091 - make gunicorn worker timeout configurable to handle larger image sizes
 
 ## [3.6.0] - 2022-08-03
 ### Changed

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -30,7 +30,9 @@ bind = "0.0.0.0:9000"
 # Worker
 # http://docs.gunicorn.org/en/stable/settings.html#worker-class
 # worker_class = os.environ.get('WORKER_CLASS', 'gevent')
-# timeout = int(os.environ.get('WORKER_TIMEOUT', 3600))  # seconds
+
+# Long s3 operations (with large files) can take more than the 30 sec default timeout
+timeout = int(os.environ.get('GUNICORN_WORKER_TIMEOUT', 3600))  # seconds
 
 # Logging
 accesslog = "-"  # stdout

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -42,3 +42,5 @@ data:
   S3_BOOT_IMAGES_BUCKET: "{{ .Values.s3.boot_images_bucket }}"
   S3_CONNECT_TIMEOUT: "{{ .Values.s3.connect_timeout }}"
   S3_READ_TIMEOUT: "{{ .Values.s3.read_timeout }}"
+
+  GUNICORN_WORKER_TIMEOUT: "{{ .Values.gunicorn.worker_timeout }}"

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -30,6 +30,9 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 
+gunicorn:
+  worker_timeout: "3600"
+
 s3:
   endpoint: ~
   ims_bucket: "ims"
@@ -138,16 +141,18 @@ cray-service:
           path: /healthz/live
         initialDelaySeconds: 5
         periodSeconds: 60
-        timeoutSeconds: 5
-        failureThreshold: 3
+        timeoutSeconds: 45
+        failureThreshold: 5
+        successThreshold: 1
       readinessProbe:
         httpGet:
           port: 9000
           path: /healthz/ready
         initialDelaySeconds: 5
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
+        periodSeconds: 60
+        timeoutSeconds: 45
+        failureThreshold: 5
+        successThreshold: 1
   volumes:
     cray-ims-data:
       name: cray-ims-data

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -144,6 +144,9 @@ def create_app():
 
     _app.data = {}
 
+    # log the gunicorn worker timeout on startup
+    _app.logger.info(f"Gunicorn worker timeout: {os.getenv('GUNICORN_WORKER_TIMEOUT', '-1')}")
+
     load_datastore(_app)
     load_v2_api(_app)
     load_v3_api(_app)


### PR DESCRIPTION
## Summary and Scope

There were timeouts configured for connections and read times, but the overall application was timing out when an s3 file operation was taking over 30 seconds.  This caused the gunicorn application that is running inside the ims pod to restart, dropping the operation that was in progress.

This change adds the timeout configuration value to the gunicorn application and makes it configurable through the helm charts and ims-config k8s configmap.

There is also a change to the readiness/liveness probes to increase their timing as well.  The way they were configured, when an operation took long enough, the liveness probe would fail and the container would be restarted mid-operation.  There should be a better solution for this put into place at some point. Currently the http server is single-threaded, so the liveness call will not be responded to until after any current operation completes.

This condition is only seen when the s3 image operations take a long time - in this case it was due to a 2Gb rootfs image.

## Issues and Related PRs
* Resolves [CASMTRAIGE-4091](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4091)

## Testing
### Tested on:
  * `Shandy`

### Test description:
I installed the test image through `helm upgrade` and the sat bootprep commands that uncovered the issue were repeated.  After multiple runs I was able to watch the ims logs and verify the gunicorn worker timeout was not being encountered any more. I also manually configured the timeout value in the ims-config configmap, restarted the ims service, and confirmed the new configuration value was used.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - needed to keep the new image on system to unblock work.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a pretty low risk change, but by increasing the liveness/readiness probe failure times it could lengthen the amount of time it takes k8s to restart a failed pod.  That should not be a common occurrence. 

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

