### PR TITLE
Release/3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.7.0] - 2022-09-28
+### Changed
+- CASMTRIAGE-4268 - pull in new ims-utils that fixes file download performance issue.
+
+## [3.6.1] - 2022-09-09
 ### Changed
 - CASMTRIAGE-4091 - make gunicorn worker timeout configurable to handle larger image sizes
 

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,6 +1,6 @@
 image: cray-ims-utils
     major: 2
-    minor: 8
+    minor: 9
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1


### PR DESCRIPTION
## Summary and Scope

Release 3.7.0:
- CASMTRIAGE-4268 - pick up new version of ims-utils that will address a file download timeout issue.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

