### PR TITLE
CASMTRIAGE-4288 - handle operations on larger images without k8s timing out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.1] - 2022-09-30
+### Changed
+- CASMTRIAGE-4288 - increase readiness/liveness times to allow for operations with larger images.
+
 ## [3.7.0] - 2022-09-28
 ### Changed
 - CASMTRIAGE-4268 - pull in new ims-utils that fixes file download performance issue.

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -140,8 +140,8 @@ cray-service:
           port: 9000
           path: /healthz/live
         initialDelaySeconds: 5
-        periodSeconds: 60
-        timeoutSeconds: 45
+        periodSeconds: 180
+        timeoutSeconds: 90
         failureThreshold: 5
         successThreshold: 1
       readinessProbe:
@@ -149,9 +149,9 @@ cray-service:
           port: 9000
           path: /healthz/ready
         initialDelaySeconds: 5
-        periodSeconds: 60
-        timeoutSeconds: 45
-        failureThreshold: 5
+        periodSeconds: 90
+        timeoutSeconds: 90
+        failureThreshold: 10
         successThreshold: 1
   volumes:
     cray-ims-data:


### PR DESCRIPTION
## Summary and Scope

The ims service is single-threaded, so while it is performing an operation it is not able to respond to liveness/readiness queries. When the image sizes get to 5-13Gb, sometimes the liveness probe will kill the ims container in the middle of an image copy.  This increases the timings to allow longer operations until we can get a better solution in place.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4288](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4288)
* Resolves [CASMTRIAGE-4268](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4268)
* Resolves [CASMTRIAGE-4091](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4091)

## Testing
### Tested on:
  * `Mug`
  * `Loki`

### Test description:

The settings were changes manually in the deployment on Loki and with these changes can successfully work with 13Gb gpu images.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

The only negative impact these helm chart changes will have is it will take k8s longer to recognize when there is a real problem with the pod. This could lead to longer times before k8s automatically restarts pods that have really stopped.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

