### PR TITLE
kata runtime class, remove memory medium from volume spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.2] - 2022-11-07
+- Add support for IMS jobs using kata-qemu runtime
+
 ## [3.7.1] - 2022-09-30
 ### Changed
 - CASMTRIAGE-4288 - increase readiness/liveness times to allow for operations with larger images.

--- a/Kata.README.md
+++ b/Kata.README.md
@@ -1,0 +1,68 @@
+# Kata Containers 
+
+Why Kata?
+We are utilizing kata to address security concerns with the overall chroot environment. Utilizing kata will allow 
+us to safely utilize the chroot environment by isolating the kernel of the pod from the node host.
+
+Starting with CSM version 1.6, kata containers will be the default runtime for IMS jobs.
+This will require that kata be installed onto the non compute nodes in order for deployment to be successful.
+
+You can verify if kata has been installed and configured in containerd by checking /etc/containerd/config.toml file and seeing this within the configuration.
+
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      privileged_without_host_devices = true
+      pod_annotations = ["io.katacontainers.*"]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
+        ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration.toml"
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu]
+      runtime_type = "io.containerd.kata-qemu.v2"
+      privileged_without_host_devices = true
+      pod_annotations = ["io.katacontainers.*"]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu.options]
+        ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml"
+
+If it doesnt exist, this block will need to be included under the [plugins."io.containerd.grpc.v1.cri".containerd]
+
+If you run into issues when trying to run an IMS job using kata. It may not be installed on the ncn in which the IMS job was scheduled.
+To install kata follow the steps below.
+
+Log in to an ncn worker and install kata directly on the node using the following commands:
+
+wget -q -c -O /tmp/kata-static.tar.xz https://github.com/kata-containers/kata-containers/releases/download/2.5.1/kata-static-2.5.1-x86_64.tar.xz
+tar -xJf /tmp/kata-static.tar.xz -C /
+chmod +x /opt/kata/bin/*
+ln -sf /opt/kata/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-qemu-v2
+sudo chown root.root /
+# shellcheck disable=SC2086,SC2046
+sudo chown root.root $(tar tJf /tmp/kata-static.tar.xz | sed 's|^|/|g' | xargs echo)
+rm /tmp/kata-static.tar.xz
+
+Try running:
+kubectl get runtimeclass
+
+If the command doesnt produce any results you will need to install the kata-qemu runtime class onto the kubernetes cluster with the following commands:
+
+cat > /tmp/qemu-class.yaml <<EOF
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: kata-qemu
+handler: kata-qemu
+overhead:
+    podFixed:
+        memory: "160Mi"
+        cpu: "250m"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+EOF
+
+kubectl apply -f /tmp/qemu-class.yaml 
+
+On the ncn you are working on:
+kubectl label node "$(hostname)" --overwrite katacontainers.io/kata-runtime=true
+This will allow the runtimeclass to schedule on the node with this label.
+
+Final step would be to drain/cordon node and reboot containerd for the changes to the config.toml file to take effect.

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -67,6 +67,7 @@ data:
           labels:
             app: ims-$id-create
         spec:
+          runtimeClassName: kata-qemu
           restartPolicy: Never  # Don't ever restart this job
           initContainers:
           # Step 1: Download and extract the image recipe archive
@@ -335,8 +336,7 @@ data:
                 cpu: "8"
           volumes:
           - name: image-vol
-            emptyDir:
-              medium: Memory
+            emptyDir: {}
           - name: recipe-vol
             emptyDir: {}
           - name: specfile-vol
@@ -345,8 +345,7 @@ data:
           - name: ca-rpm-vol
             emptyDir: {}
           - name: ims-config-vol
-            emptyDir:
-              medium: Memory
+            emptyDir: {}
           - name: ca-pubkey
             configMap:
               name: cray-configmap-ca-public-key

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
@@ -65,6 +65,7 @@ data:
           labels:
             app: ims-$id-create
         spec:
+          runtimeClassName: kata-qemu
           restartPolicy: Never  # Don't ever restart this job
           initContainers:
           # Step 1: Pull the image recipe from the configmap location
@@ -257,8 +258,7 @@ data:
                 cpu: "8"
           volumes:
           - name: image-vol
-            emptyDir:
-              medium: Memory
+            emptyDir: {}
           - name: recipe-vol
             emptyDir: {}
           - name: specfile-vol
@@ -267,8 +267,7 @@ data:
           - name: ca-rpm-vol
             emptyDir: {}
           - name: ims-config-vol
-            emptyDir:
-              medium: Memory
+            emptyDir: {}
           - name: ca-pubkey
             configMap:
               name: cray-configmap-ca-public-key

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -65,6 +65,7 @@ data:
           labels:
             app: ims-$id-customize
         spec:
+          runtimeClassName: kata-qemu
           restartPolicy: Never  # Don't ever restart this job
           initContainers:
           # Step 1: Download and extract the image root filesystem
@@ -219,11 +220,9 @@ data:
               readOnly: true
           volumes:
           - name: image-vol
-            emptyDir:
-              medium: Memory
+            emptyDir: {}
           - name: ims-config-vol
-            emptyDir:
-              medium: Memory
+            emptyDir: {}
           - name: ca-pubkey
             configMap:
               name: cray-configmap-ca-public-key


### PR DESCRIPTION
## Summary and Scope

Changes the default runtime of ims jobs to be that of kata-qemu. 
Changes the medium for emptyDir from memory to blank. This is due to a limitation of kata utilizing volume subpaths.
See. https://github.com/kata-containers/runtime/issues/1341

## Testing

_List the environments in which these changes were tested._

### Tested on:
Mug 

### Test description:
IMS jobs utilizing kata-qemu runtimeclass to successfully build and customize IMS images.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Wont work if kata is not installed on the system.


