### PR TITLE
CASMTRIAGE-4680: Use credentials to authenticate to artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- CASMTRIAGE-4680: Use authentication credentials to validate to artifactory
 
 ## [3.5.0] - 2022-06-30
 ### Added

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -62,7 +62,9 @@ pipeline {
 
         stage("runBuildPrep") {
             steps {
-                sh "make runbuildprep"
+	        withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                    sh "make runbuildprep"
+                }
             }
         }
 


### PR DESCRIPTION
## Summary and Scope

Use credentials to authenticate to artifactory

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-4680

## Testing


### Tested on:

  * Build system

### Test description:

I built it. The build was breaking and now it's now.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Nonexistent


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

