### PR TITLE
CASMCMS-8347 - update istio api interface version to v1beta1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [3.8.2] - 2022-12-22
+### Changed
+- CASMCMS-8347 - update istio api interface version to 'v1beta1'
+
 ## [3.8.1] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile
-
-## [Unreleased]
 
 ## [3.8.0] - 2022-12-16
 ### Added

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -88,7 +88,7 @@ customer_access:
   subnet_name: "cmn"
 
 jobs:
-  enable_dkms: False
+  enable_dkms: false
   kata_runtime: "kata-qemu"
 
 cray-service:

--- a/src/server/v2/resources/jobs.py
+++ b/src/server/v2/resources/jobs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -70,7 +70,7 @@ class V2BaseJobResource(Resource):
 
         self.k8scrds = client.CustomObjectsApi(client.ApiClient())
 
-        self.ISTIO_RESOURCE_VERSION = 'v1alpha3'
+        self.ISTIO_RESOURCE_VERSION = 'v1beta1'
         self.ISTIO_RESOURCE_GROUP = 'networking.istio.io'
         self.ISTIO_RESOURCE_DESTINATION_RULE = 'DestinationRule'
         self.ISTIO_RESOURCE_DESTINATION_RULES = 'destinationrules'

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -70,7 +70,7 @@ class V3BaseJobResource(Resource):
 
         self.k8scrds = client.CustomObjectsApi(client.ApiClient())
 
-        self.ISTIO_RESOURCE_VERSION = 'v1alpha3'
+        self.ISTIO_RESOURCE_VERSION = 'v1beta1'
         self.ISTIO_RESOURCE_GROUP = 'networking.istio.io'
         self.ISTIO_RESOURCE_DESTINATION_RULE = 'DestinationRule'
         self.ISTIO_RESOURCE_DESTINATION_RULES = 'destinationrules'


### PR DESCRIPTION
## Summary and Scope

Update the k8s api interface used for the istio service. This will bring us up to date with the most recent version and keep us from having depreciation problems as k8s is upgraded.

## Issues and Related PRs
* Resolves [CASMCMS-8347](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8347)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I upgraded the image being used on surtur and verified that jobs started correctly and the istio connections are created successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as it upgrades the interface version but there are no differences in this particular use case.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

