### PR TITLE
CASMCMS-8382: Correct openapi spec to match actual API behavior; minor linting of spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8382 - Correct openapi.yaml to match actual API behavior. Linting of language and formatting of same.
 
 ## [3.8.2] - 2022-12-22
 ### Changed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,130 +26,116 @@ openapi: 3.0.2
 
 info:
   description: >
-    The Image Management Service (IMS) creates and customizes
-    boot images which run on compute nodes.
-    A boot image consists of multiple image
-    artifacts including the root file system (rootfs), kernel and initrd. There are
-    optionally additional artifacts such as debug symbols, etc. 
+    The Image Management Service (IMS) creates and customizes boot images which run on compute
+    nodes. A boot image consists of multiple image artifacts including the root file system
+    (rootfs), kernel, and initrd. There are optionally additional artifacts such as debug symbols,
+    etc.
 
-    IMS uses the open source Kiwi-NG tool to
-    build image roots from compressed Kiwi image descriptions (recipes).
-    Kiwi-NG is able to build images based on a variety of different
-    Linux distributions, specifically SUSE, RHEL and
-    their derivatives.
+    IMS uses the open source Kiwi-NG tool to build image roots from compressed Kiwi image
+    descriptions (recipes). Kiwi-NG is able to build images based on a variety of different Linux
+    distributions, specifically SUSE, RHEL, and their derivatives.
 
-    A user may choose to use the provided recipes or 
-    customize Kiwi recipes to define the image
-    to be built.
+    A user may choose to use the provided recipes or customize Kiwi recipes to define the image to
+    be built.
 
-    IMS creates and customizes existing boot images and maintains metadata about the images
-    and related artifacts. IMS accesses and stores the recipes, images, and related artifacts
-    in the artifact repository. 
+    IMS creates and customizes existing boot images and maintains metadata about the images and
+    related artifacts. IMS accesses and stores the recipes, images, and related artifacts in the
+    artifact repository.
 
-    ## Resources 
+    ## Resources
 
-    ### /images 
-      
-      Manipulate ImageRecords, which relate multiple image artifact records together.
+      ### /images
 
-    ### /jobs  
+        Manipulate ImageRecords, which relate multiple image artifact records together.
 
-      Initiate image creation or customization.  It creates the image which it uploads to 
-      the artifact repository,
-      and maintains associated metadata in IMS for subsequent access. It also customizes a pre-existing
-      image.
+      ### /jobs
 
-    ### /public-keys
+        Initiate image creation or customization.  It creates the image which it uploads to the
+        artifact repository, and maintains associated metadata in IMS for subsequent access. It
+        also customizes a pre-existing image.
 
-      Manage the public keys which enable ssh access. 
-      Public-keys are created and uploaded by the
-      administrator to allow access to ssh shells provided
-      by IMS during image creation and customization.
+      ### /public-keys
 
+        Manage the public keys which enable SSH access. Public-keys are created and uploaded by the
+        administrator to allow access to SSH shells provided by IMS during image creation and
+        customization.
 
-    ### /recipes 
+      ### /recipes
 
-      Manipulate the RecipeRecord metadata about the Kiwi-NG recipes 
-      which are stored in the artifact repository. 
-      Recipes themselves define how an image is to be created including the
-      RPMS that will be installed, the RPM repos to use, etc. 
-       
+        Manipulate the RecipeRecord metadata about the Kiwi-NG recipes which are stored in the
+        artifact repository. Recipes themselves define how an image is to be created, including the
+        RPMs that will be installed, the RPM repositories to use, etc.
 
     ## Workflows
 
-      There are two main workflows using the IMS - image creation and image customization.  
-      The IMS /jobs endpoint directs the creation of a new image, or 
-      the customization of an existing image, depending on the POST /jobs request body parameter, job_type.
-    
-    ### Add a New Recipe
+      There are two main workflows using the IMS - image creation and image customization.
+      The IMS /jobs endpoint directs the creation of a new image, or the customization of an
+      existing image, depending on the POST /jobs request job_type body parameter.
 
-    #### GET /recipes 
-       
-      Obtain list of existing recipes which are registered with IMS.
+      ### Add a New Recipe
 
-    #### Upload recipe using CLI
-       
-      Upload a new recipe to the artifact repository using the cray artifacts command, if necessary.
-      Refer to Administrator's Guide for instructions.
-      
-    #### POST /recipes
-    
-      Register new recipe with IMS. 
+        #### GET /recipes
 
-    ### Manage Public Keys
-    
-    #### GET /public-keys
-    
-      Obtain list of available public-keys.
-       
-    #### POST /public-keys
-    
-      Add a new public-key.
+          Obtain list of existing recipes which are registered with IMS.
 
-    ### Create a New Image
-      
-    #### GET /public-keys
-    
-    Get a list of available keys.
-      
-    #### GET /recipes
-    
-     Get recipe id.
-      
-      #### POST /jobs
-      
-      Use Kiwi-NG to create a new IMS image and image artifacts from a recipe,
-      Specify job_type "create" in JobRecord. 
-      Request body parameters supply the recipe id and public key id.
-      Upon success,
-      the artifact repository contains the new image and the image artifacts,
-      IMS contains a new ImageRecord - metadata for the new image.
-      During the creation process, IMS may create an ssh shell for
-      administrator interaction with the image for
-      debugging, if necessary.  (enable_debug = true in JobRecord)
+        #### Upload recipe using CLI
 
-    ### Modify an Image
-      
-    #### GET /public-keys
-    
-    Get a list of available keys.
-      
-    #### GET /images
-    
-    Obtain a list of available images registered in IMS.
-      
-    #### POST /jobs
-    
-      To create a modified version of an existing IMS image, 
-      specify job_type "customize". Specify the IMS id of the existing image, and
-      public key.  This request creates a copy of the existing image,
-      and then an interactive ssh shell
-      in which to modify the copy of the image.  Upon success,
-      the artifact repository contains the original image and a modified version of it. IMS contains 
-      a new ImageRecord - metadata for the modified image.
-      The original image is still intact.  A user may want to install additional software, 
-      install licenses, change the timezone, add mount points, etc.
-    
+          Upload a new recipe to the artifact repository using the cray artifacts command, if necessary.
+          Refer to Administrator's Guide for instructions.
+
+        #### POST /recipes
+
+          Register new recipe with IMS.
+
+      ### Manage Public Keys
+
+        #### GET /public-keys
+
+          Obtain list of available public-keys.
+
+        #### POST /public-keys
+
+          Add a new public-key.
+
+      ### Create a New Image
+
+        #### GET /public-keys
+
+          Get a list of available keys.
+
+        #### GET /recipes
+
+          Get recipe ID.
+
+        #### POST /jobs
+
+          Use Kiwi-NG to create a new IMS image and image artifacts from a recipe. Specify job_type
+          "create" in JobRecord. Request body parameters supply the recipe ID and public key ID.
+          Upon success, the artifact repository contains the new image and the image artifacts,
+          IMS contains a new ImageRecord with metadata for the new image. During the creation
+          process, IMS may create an SSH shell for administrator interaction with the image for
+          debugging, if necessary.  (enable_debug = true in JobRecord)
+
+      ### Modify an Image
+
+        #### GET /public-keys
+
+          Get a list of available keys.
+
+        #### GET /images
+
+          Obtain a list of available images registered in IMS.
+
+        #### POST /jobs
+
+          To create a modified version of an existing IMS image, specify job_type "customize".
+          Specify the IMS ID of the existing image, and public key.  This request creates a copy of
+          the existing image, and then an interactive SSH shell in which to modify the copy of the
+          image. Upon success, the artifact repository contains the original image and a modified
+          version of it. IMS contains a new ImageRecord with metadata for the modified image. The
+          original image is still intact.  A user may want to install additional software, install
+          licenses, change the timezone, add mount points, etc.
+
   version: "0.0.0-imsserv"
   title: Image Management Service
   license:
@@ -176,7 +162,7 @@ tags:
   - name: v2
     description: "IMS v2 API"
   - name: v3
-    description: "IMS v3 API "   
+    description: "IMS v3 API"
 
 paths:
   /v3/recipes:
@@ -204,7 +190,7 @@ paths:
       tags:
         - recipes
         - v3
-      description: >
+      description: >-
         Create a new RecipeRecord in IMS.
 
         A compressed Kiwi-NG image description is actually stored in the artifact repository.
@@ -219,13 +205,11 @@ paths:
         required: true
       responses:
         '201':
-          description: A collection of recipes
+          description: New Recipe record
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/RecipeRecord'
-                type: array
+                $ref: '#/components/schemas/RecipeRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -238,9 +222,10 @@ paths:
       tags:
         - recipes
         - v3
-      description: >
+      description: >-
         Delete all RecipeRecords. Deleted recipes are soft deleted and added to the /deleted/recipes endpoint.
         The S3 key for associated artifacts is renamed.
+
       responses:
         '204':
           description: Recipe records deleted successfully
@@ -250,12 +235,12 @@ paths:
     parameters:
       - $ref: '#/components/parameters/recipe_id'
     get:
-      summary: Retrieve RecipeRecord by id
+      summary: Retrieve RecipeRecord by ID
       operationId: get_v3_recipe
       tags:
         - recipes
         - v3
-      description: Retrieve a RecipeRecord by id
+      description: Retrieve a RecipeRecord by ID
       responses:
         '200':
           description: A recipe record
@@ -271,8 +256,7 @@ paths:
       tags:
         - recipes
         - v3
-      description: >
-        Update a RecipeRecord in IMS.
+      description: Update a RecipeRecord in IMS.
       requestBody:
         content:
           application/json:
@@ -282,7 +266,7 @@ paths:
         required: true
       responses:
         '200':
-          description: A Recipe record
+          description: Updated Recipe record
           content:
             application/json:
               schema:
@@ -298,14 +282,15 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
-      summary: Soft delete a RecipeRecord by id
+      summary: Soft delete a RecipeRecord by ID
       operationId: delete_v3_recipe
       tags:
         - recipes
         - v3
-      description: >
-        Delete a RecipeRecord by id. The deleted recipes are soft deleted and added to the /deleted/recipes endpoint.
+      description: >-
+        Delete a RecipeRecord by ID. The deleted recipes are soft deleted and added to the /deleted/recipes endpoint.
         The S3 key for the associated artifact is renamed.
+
       responses:
         '204':
           description: Recipe record deleted successfully
@@ -320,10 +305,11 @@ paths:
       tags:
         - images
         - v3
-      description: >
+      description: >-
         Retrieve a list of ImageRecords indicating images that are registered
-        with IMS. The ImageRecord id is used to associate multiple image artifacts
+        with IMS. The ImageRecord ID is used to associate multiple image artifacts
         together (kernel, initrd, rootfs (squashfs)).
+
       responses:
         '200':
           description: A collection of images
@@ -351,13 +337,11 @@ paths:
         required: true
       responses:
         '201':
-          description: A collection of images
+          description: New image record
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/ImageRecord'
-                type: array
+                $ref: '#/components/schemas/ImageRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -370,9 +354,10 @@ paths:
       tags:
         - images
         - v3
-      description: >
+      description: >-
         Delete all ImageRecords. Deleted images are soft deleted and added to the /deleted/images endpoint.
         The S3 key for the associated image manifests are renamed.
+
       responses:
         '204':
           description: Image records deleted successfully
@@ -415,7 +400,7 @@ paths:
         required: true
       responses:
         '200':
-          description: An Image record
+          description: Updated Image record
           content:
             application/json:
               schema:
@@ -431,9 +416,10 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
-      description: >
-        Delete an ImageRecord by Id. Deleted images are soft deleted and added to the /deleted/images endpoint.
+      description: >-
+        Delete an ImageRecord by ID. Deleted images are soft deleted and added to the /deleted/images endpoint.
         The S3 key for the associated image manifest is renamed.
+
       operationId: delete_v3_image
       tags:
         - images
@@ -448,12 +434,12 @@ paths:
       summary: Soft delete ImageRecord by image_id
   /v3/public-keys:
     get:
-      summary: 'List public ssh keys '
+      summary: List public SSH keys
       operationId: get_all_v3_public_keys
       tags:
         - public keys
         - v3
-      description: Retrieve a list of public ssh keys that are registered with IMS.
+      description: Retrieve a list of public SSH keys that are registered with IMS.
       responses:
         '200':
           description: A collection of keypairs
@@ -466,20 +452,18 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     post:
-      summary: Create a new public ssh key record
+      summary: Create a new public SSH key record
       operationId: post_v3_public_key
       tags:
         - public keys
         - v3
-      description: Create a new public ssh key record. Uploaded by administrator to allow them to access
-        ssh shells that IMS provides.
+      description: Create a new public SSH key record. Uploaded by administrator to allow them to access SSH shells that IMS provides.
       requestBody:
         content:
           application/json:
             schema:
-              items:
-                $ref: '#/components/schemas/PublicKeyRecord'
-        description: public key record to create
+              $ref: '#/components/schemas/PublicKeyRecord'
+        description: Public key record to create
         required: true
       responses:
         '201':
@@ -487,8 +471,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PublicKeyRecord'
+                $ref: '#/components/schemas/PublicKeyRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -501,8 +484,7 @@ paths:
       tags:
         - public keys
         - v3
-      description: >
-        Delete all public key-records. Deleted public-keys are soft deleted and added to the /deleted/public-keys endpoint.
+      description: Delete all public key-records. Deleted public-keys are soft deleted and added to the /deleted/public-keys endpoint.
       responses:
         '204':
           description: Public key records deleted successfully
@@ -524,8 +506,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PublicKeyRecord'
+                $ref: '#/components/schemas/PublicKeyRecord'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -536,9 +517,7 @@ paths:
       tags:
         - public keys
         - v3
-      description: >
-        Delete a PublicKeyRecord by Id. Deleted public-keys are soft deleted and added to the /deleted/public-keys
-        endpoint.
+      description: Delete a PublicKeyRecord by ID. Deleted public-keys are soft deleted and added to the /deleted/public-keys endpoint.
       responses:
         '204':
           description: Public Key record deleted successfully
@@ -582,7 +561,7 @@ paths:
         * Call kiwi-ng, which builds the image root using
           the recipe in artifact repository and accesses packages in zypper/yum repositories.
         * Upload the new image to the artifact repository, and save metadata to IMS - ImageRecord.
-        * If there is a failure, establish debug ssh shell, depending on value of enable_debug.  Admin
+        * If there is a failure, establish debug SSH shell, depending on value of enable_debug.  Admin
           can inspect image build root.
           **touch /mnt/image/complete** in a non-jailed environment or
           **touch /tmp/complete** in a jailed (chroot) environment to exit.
@@ -593,7 +572,7 @@ paths:
           the ImageRecord to read the Image's manifest.yaml to find the Image's
           root file system (rootfs) artifact.  IMS downloads the rootfs from the artifact
           repository and uncompresses it.
-        * IMS creates an ssh environment so admin can inspect and modify the image.
+        * IMS creates an SSH environment so admin can inspect and modify the image.
           For example, it may be necessary to modify the timezone, or
           modify the programming environment, etc.
           **touch /mnt/image/complete** in a non-jailed
@@ -617,7 +596,7 @@ paths:
         required: true
       responses:
         '201':
-          description: A job record
+          description: New job record
           content:
             application/json:
               schema:
@@ -697,7 +676,7 @@ paths:
         required: true
       responses:
         '200':
-          description: A job record
+          description: Updated job record
           content:
             application/json:
               schema:
@@ -718,8 +697,8 @@ paths:
         - v3
       description: >-
         Delete a job record by job_id. This also deletes the underlying
-        Kubernetes resources that were created when the job
-        record was submitted.
+        Kubernetes resources that were created when the job record was submitted.
+
       responses:
         '204':
           description: Job record deleted successfully
@@ -752,8 +731,7 @@ paths:
       tags:
         - recipes
         - v3
-      description: >
-        Permanently delete all DeletedRecipeRecords. Associated artifacts are permanently deleted from S3.
+      description: Permanently delete all DeletedRecipeRecords. Associated artifacts are permanently deleted from S3.
       responses:
         '204':
           description: Recipe records were permanently deleted
@@ -765,8 +743,7 @@ paths:
       tags:
         - recipes
         - v3
-      description: >
-        Restore all DeletedRecipeRecords in IMS.
+      description: Restore all DeletedRecipeRecords in IMS.
       requestBody:
         content:
           application/json:
@@ -791,12 +768,12 @@ paths:
     parameters:
       - $ref: '#/components/parameters/deleted_recipe_id'
     get:
-      summary: Retrieve DeletedRecipeRecord by id
+      summary: Retrieve DeletedRecipeRecord by ID
       operationId: get_v3_deleted_recipe
       tags:
         - recipes
         - v3
-      description: Retrieve a DeletedRecipeRecord by id
+      description: Retrieve a DeletedRecipeRecord by ID
       responses:
         '200':
           description: A deleted recipe record
@@ -807,13 +784,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
     delete:
-      summary: Permanently delete a DeletedRecipeRecord by id
+      summary: Permanently delete a DeletedRecipeRecord by ID
       operationId: delete_v3_deleted_recipe
       tags:
         - recipes
         - v3
-      description: >
-        Permanently delete a DeletedRecipeRecord by id. Associated artifacts are permanently deleted from S3.
+      description: Permanently delete a DeletedRecipeRecord by ID. Associated artifacts are permanently deleted from S3.
       responses:
         '204':
           description: RecipeRecord was permanently deleted
@@ -827,8 +803,7 @@ paths:
       tags:
         - recipes
         - v3
-      description: >
-        Restore a DeletedRecipeRecord in IMS.
+      description: Restore a DeletedRecipeRecord in IMS.
       requestBody:
         content:
           application/json:
@@ -874,8 +849,7 @@ paths:
       tags:
         - images
         - v3
-      description: >
-        Permanently delete all DeletedImageRecords. Associated artifacts are permanently deleted from S3.
+      description: Permanently delete all DeletedImageRecords. Associated artifacts are permanently deleted from S3.
       responses:
         '204':
           description: Image records were permanently deleted
@@ -887,8 +861,7 @@ paths:
       tags:
         - images
         - v3
-      description: >
-        Restore all DeletedImageRecords in IMS.
+      description: Restore all DeletedImageRecords in IMS.
       requestBody:
         content:
           application/json:
@@ -925,16 +898,16 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DeletedImageRecord'
+                $ref: '#/components/schemas/DeletedImageRecord'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
-      description: >
+      description: >-
         Permanently delete image record associated with deleted_image_id. Associated artifacts
         are permanently deleted from S3.
+
       operationId: delete_v3_deleted_image
       tags:
         - images
@@ -976,12 +949,12 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /v3/deleted/public-keys:
     get:
-      summary: List deleted public ssh keys
+      summary: List deleted public SSH keys
       operationId: get_all_v3_deleted_public_keys
       tags:
         - public keys
         - v3
-      description: Retrieve a list of deleted public ssh keys that are registered with IMS.
+      description: Retrieve a list of deleted public SSH keys that are registered with IMS.
       responses:
         '200':
           description: A collection of keypairs
@@ -999,8 +972,7 @@ paths:
       tags:
         - public keys
         - v3
-      description: >
-        Permanently delete all public key-records.
+      description: Permanently delete all public key-records.
       responses:
         '204':
           description: PublicKey records were permanently deleted
@@ -1012,8 +984,7 @@ paths:
       tags:
         - public keys
         - v3
-      description: >
-        Restore all DeletedPublicKeyRecord in IMS.
+      description: Restore all DeletedPublicKeyRecord in IMS.
       requestBody:
         content:
           application/json:
@@ -1050,8 +1021,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DeletedPublicKeyRecord'
+                $ref: '#/components/schemas/DeletedPublicKeyRecord'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1062,8 +1032,7 @@ paths:
       tags:
         - public keys
         - v3
-      description: >
-        Permanently delete a DeletedPublicKeyRecord by Id.
+      description: Permanently delete a DeletedPublicKeyRecord by ID.
       responses:
         '204':
           description: PublicKeyRecord was permanently deleted
@@ -1123,7 +1092,7 @@ paths:
       tags:
         - recipes
         - v2
-      description: >
+      description: >-
         Create a new RecipeRecord in IMS.
 
         A compressed Kiwi-NG image description is actually stored in the artifact repository.
@@ -1138,12 +1107,11 @@ paths:
         required: true
       responses:
         '201':
-          description: A recipe record
+          description: New recipe record
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/RecipeRecord'  
+                $ref: '#/components/schemas/RecipeRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -1174,12 +1142,12 @@ paths:
     parameters:
       - $ref: '#/components/parameters/recipe_id'
     get:
-      summary: Retrieve RecipeRecord by id
+      summary: Retrieve RecipeRecord by ID
       operationId: get_v2_recipe
       tags:
         - recipes
         - v2
-      description: Retrieve a RecipeRecord by id
+      description: Retrieve a RecipeRecord by ID
       responses:
         '200':
           description: A recipe record
@@ -1195,8 +1163,7 @@ paths:
       tags:
         - recipes
         - v2
-      description: >
-        Update a RecipeRecord in IMS.
+      description: Update a RecipeRecord in IMS.
       requestBody:
         content:
           application/json:
@@ -1206,7 +1173,7 @@ paths:
         required: true
       responses:
         '200':
-          description: A Recipe record
+          description: Updated Recipe record
           content:
             application/json:
               schema:
@@ -1222,12 +1189,12 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
-      summary: Delete a RecipeRecord by id
+      summary: Delete a RecipeRecord by ID
       operationId: delete_v2_recipe
       tags:
         - recipes
         - v2
-      description: Delete a recipe by id.
+      description: Delete a recipe by ID.
       parameters:
         - in: query
           name: cascade
@@ -1249,9 +1216,10 @@ paths:
       tags:
         - images
         - v2
-      description: Retrieve a list of ImageRecords indicating images that are registered
-        with the IMS. The ImageRecord id is used to associate multiple image artifacts
-        together (kernel, initrd, rootfs (squashfs)).
+      description: >-
+        Retrieve a list of ImageRecords indicating images that are registered with the IMS.
+        The ImageRecord ID is used to associate multiple image artifacts together (kernel, initrd, rootfs (squashfs)).
+
       responses:
         '200':
           description: A collection of images
@@ -1279,12 +1247,11 @@ paths:
         required: true
       responses:
         '201':
-          description: new image record
+          description: New image record
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DeletedImageRecord'
+                $ref: '#/components/schemas/DeletedImageRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -1327,8 +1294,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/ImageRecord'
+                $ref: '#/components/schemas/ImageRecord'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1349,7 +1315,7 @@ paths:
         required: true
       responses:
         '200':
-          description: An Image record
+          description: Updated Image record
           content:
             application/json:
               schema:
@@ -1387,12 +1353,12 @@ paths:
       summary: Delete ImageRecord by image_id
   /v2/public-keys:
     get:
-      summary: 'List public ssh keys '
+      summary: List public SSH keys
       operationId: get_all_v2_public_keys
       tags:
         - public keys
         - v2
-      description: Retrieve a list of public ssh keys that are registered with IMS.
+      description: Retrieve a list of public SSH keys that are registered with IMS.
       responses:
         '200':
           description: A collection of keypairs
@@ -1405,21 +1371,18 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     post:
-      summary: Create a new public ssh key record
+      summary: Create a new public SSH key record
       operationId: post_v2_public_key
       tags:
         - public keys
         - v2
-      description: Create a new public ssh key record. Uploaded by administrator to allow them to access
-        ssh shells that IMS provides.
+      description: Create a new public SSH key record. Uploaded by administrator to allow them to access SSH shells that IMS provides.
       requestBody:
         content:
           application/json:
             schema:
-              type: array
-              items: 
-                $ref: '#/components/schemas/PublicKeyRecord'
-        description: public key record to create
+              $ref: '#/components/schemas/PublicKeyRecord'
+        description: Public key record to create
         required: true
       responses:
         '201':
@@ -1427,9 +1390,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PublicKeyRecord'
+                $ref: '#/components/schemas/PublicKeyRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -1465,8 +1426,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PublicKeyRecord'
+                $ref: '#/components/schemas/PublicKeyRecord'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1521,7 +1481,7 @@ paths:
         * Call kiwi-ng, which builds the image root using
           the recipe in artifact repository and accesses packages in zypper/yum repositories.
         * Upload the new image to the artifact repository, and save metadata to IMS - ImageRecord.
-        * If there is a failure, establish debug ssh shell, depending on value of enable_debug.  Admin
+        * If there is a failure, establish debug SSH shell, depending on value of enable_debug.  Admin
           can inspect image build root.
           **touch /mnt/image/complete** in a non-jailed environment or
           **touch /tmp/complete** in a jailed (chroot) environment to exit.
@@ -1532,7 +1492,7 @@ paths:
           the ImageRecord to read the Image's manifest.yaml to find the Image's
           root file system (rootfs) artifact.  IMS downloads the rootfs from the artifact
           repository and uncompresses it.
-        * IMS creates an ssh environment so admin can inspect and modify the image.
+        * IMS creates an SSH environment so admin can inspect and modify the image.
           For example, it may be necessary to modify the timezone, or
           modify the programming environment, etc.
           **touch /mnt/image/complete** in a non-jailed
@@ -1560,8 +1520,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/JobRecord'        
+                $ref: '#/components/schemas/JobRecord'
         '400':
           $ref: '#/components/responses/NoInputProvided'
         '422':
@@ -1661,6 +1620,7 @@ paths:
         Delete a job record by job_id. This also deletes the underlying
         Kubernetes resources that were created when the job
         record was submitted.
+
       responses:
         '204':
           description: Job record deleted successfully
@@ -1694,6 +1654,7 @@ paths:
       description: >-
         Readiness probe for IMS. This is used by Kubernetes to determine if IMS
         is ready to accept requests.
+
       responses:
         200:
           description: IMS is ready to accept requests
@@ -1713,6 +1674,7 @@ paths:
       description: >-
         Liveness probe for IMS. This is used by Kubernetes to determine if IMS
         is responsive
+
       responses:
         200:
           description: IMS is responsive
@@ -1745,7 +1707,7 @@ paths:
 components:
   parameters:
     image_id:
-      description: The unique id of an image
+      description: The unique ID of an image
       in: path
       name: image_id
       required: true
@@ -1754,7 +1716,7 @@ components:
         format: uuid
       example: 20ad9d0f-3057-4ba8-8c6c-cd31b54c5947
     deleted_image_id:
-      description: The unique id of a deleted image
+      description: The unique ID of a deleted image
       in: path
       name: deleted_image_id
       required: true
@@ -1763,7 +1725,7 @@ components:
         format: uuid
       example: f5d9c785-aef7-4f83-86b0-2f619186c6a6
     public_key_id:
-      description: The unique id of a public key
+      description: The unique ID of a public key
       in: path
       name: public_key_id
       required: true
@@ -1772,7 +1734,7 @@ components:
         format: uuid
       example: 66db1862-fa14-44c6-ae4b-6a6cc8cdc34a
     deleted_public_key_id:
-      description: The unique id of a deleted public key
+      description: The unique ID of a deleted public key
       in: path
       name: deleted_public_key_id
       required: true
@@ -1781,7 +1743,7 @@ components:
         format: uuid
       example: bc6ec895-6ff5-4481-bd98-88ed4cd233e9
     job_id:
-      description: The unique id of a job
+      description: The unique ID of a job
       in: path
       name: job_id
       required: true
@@ -1790,7 +1752,7 @@ components:
         format: uuid
       example: d77ef3de-5400-482e-a579-88114b8bf2d2
     recipe_id:
-      description: The unique id of a recipe
+      description: The unique ID of a recipe
       in: path
       name: recipe_id
       required: true
@@ -1799,7 +1761,7 @@ components:
         format: uuid
       example: 127ee397-1a4d-417f-8db5-3816609c6309
     deleted_recipe_id:
-      description: The unique id of a deleted recipe
+      description: The unique ID of a deleted recipe
       in: path
       name: recipe_id
       required: true
@@ -1812,6 +1774,7 @@ components:
       description: >-
         Input data was understood, but failed validation. Re-run request with
         valid input values for the fields indicated in the response.
+
       content:
         application/json:
           schema:
@@ -1820,6 +1783,7 @@ components:
       description: >-
         No input provided. Determine the specific information that is missing or
         invalid and then re-run the request with valid information.
+
       content:
         application/json:
           schema:
@@ -1837,9 +1801,7 @@ components:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
     InternalServerError:
-      description: >-
-        An internal error occurred. Re-running the request may or may not
-        succeed.
+      description: An internal error occurred. Re-running the request may or may not succeed.
       content:
         application/json:
           schema:
@@ -1849,16 +1811,12 @@ components:
       properties:
         host:
           type: string
-          description: >-
-            IP or host name to use, in combination with the port, to connect to
-            the ssh container
+          description: IP or host name to use, in combination with the port, to connect to the SSH container
           example: 10.100.20.221
           readOnly: true
         port:
           type: integer
-          description: >-
-            Port to use, in combination with the host, to connect to the ssh
-            container
+          description: Port to use, in combination with the host, to connect to the SSH container
           example: 22
           readOnly: true
     SSHConnectionMap:
@@ -1871,19 +1829,17 @@ components:
         - jail
       properties:
         name:
-          description: Name of the ssh container
+          description: Name of the SSH container
           type: string
           example: customize
           maxLength: 40
           minLength: 1
         jail:
-          description: 'If true, establish an ssh jail, or chroot environment.'
+          description: 'If true, establish an SSH jail, or chroot environment.'
           type: boolean
           example: true
         status:
-          description: >-
-            Status of the ssh container (pending, establishing, active,
-            complete)
+          description: Status of the SSH container (pending, establishing, active, complete)
           type: string
           example: pending
           readOnly: true
@@ -1898,16 +1854,13 @@ components:
             A human-readable explanation specific to this occurrence of the
             problem. Focus on helping correct the problem, rather than giving
             debugging information.
+
           type: string
         errors:
-          description: >-
-            An object denoting field-specific errors. Only present on error
-            responses when field input is specified for the request.
+          description: An object denoting field-specific errors. Only present on error responses when field input is specified for the request.
           type: object
         instance:
-          description: >-
-            A relative URI reference that identifies the specific occurrence of
-            the problem
+          description: A relative URI reference that identifies the specific occurrence of the problem
           format: uri
           type: string
         status:
@@ -1915,15 +1868,11 @@ components:
           example: 400
           type: integer
         title:
-          description: >-
-            Short, human-readable summary of the problem, should not change by
-            occurrence.
+          description: Short, human-readable summary of the problem, should not change by occurrence.
           type: string
         type:
           default: 'about:blank'
-          description: >-
-            Relative URI reference to the type of problem which includes human
-            readable documentation.
+          description: Relative URI reference to the type of problem which includes human-readable documentation.
           format: uri
           type: string
     PublicKeyRecord:
@@ -1934,7 +1883,7 @@ components:
         - public_key
       properties:
         id:
-          description: Unique id of the image
+          description: Unique ID of the image
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -1955,6 +1904,7 @@ components:
           example: >-
             ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA ...
             fa6hG9i2SzfY8L6vAVvSE7A2ILAsVruw1Zeiec2IWt
+
           type: string
           minLength: 1
     DeletedPublicKeyRecord:
@@ -1965,7 +1915,7 @@ components:
         - public_key
       properties:
         id:
-          description: Unique id of the image
+          description: Unique ID of the image
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -1992,6 +1942,7 @@ components:
           example: >-
             ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA ...
             fa6hG9i2SzfY8L6vAVvSE7A2ILAsVruw1Zeiec2IWt
+
           type: string
           minLength: 1
     ArtifactLinkRecord:
@@ -2037,8 +1988,8 @@ components:
         - linux_distribution
       properties:
         id:
-          description: Unique id of the recipe
-          # Unique id of the recipe - same or different from other ID?  Then example should reflect similarity or difference ?
+          description: Unique ID of the recipe
+          # Unique ID of the recipe - same or different from other ID?  Then example should reflect similarity or difference ?
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -2084,8 +2035,8 @@ components:
         - linux_distribution
       properties:
         id:
-          description: Unique id of the recipe
-          # Unique id of the recipe - same or different from other ID?  Then example should reflect similarity or difference ?
+          description: Unique ID of the recipe
+          # Unique ID of the recipe - same or different from other ID?  Then example should reflect similarity or difference ?
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -2136,8 +2087,7 @@ components:
         - name
       properties:
         id:
-          description: >
-            Unique id of the image.
+          description: Unique ID of the image.
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -2163,7 +2113,7 @@ components:
       properties:
         id:
           description: >
-            Unique id of the image.
+            Unique ID of the image.
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -2203,7 +2153,7 @@ components:
         - image_root_archive_name
       properties:
         id:
-          description: Unique id of the job
+          description: Unique ID of the job
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           readOnly: true
@@ -2217,32 +2167,24 @@ components:
         job_type:
           $ref: '#/components/schemas/JobTypes'
         image_root_archive_name:
-          description: >-
-            Name to be given to the imageroot artifact (do not include
-            .sqshfs or other extensions)
+          description: Name to be given to the imageroot artifact (do not include .sqshfs or other extensions)
           example: cray-sles12-sp3-barebones
           type: string
           minLength: 1
         kernel_file_name:
-          description: >-
-            Name of the kernel file to extract and upload to the artifact repository from the /boot
-            directory of the image root.
+          description: Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.
           default: vmlinuz
           example: vmlinuz
           type: string
           minLength: 1
         initrd_file_name:
-          description: >-
-            Name of the initrd image file to extract and upload to the artifact repository from the
-            /boot directory of the image root.
+          description: Name of the initrd image file to extract and upload to the artifact repository from the /boot directory of the image root.
           default: initrd
           example: initrd
           type: string
           minLength: 1
         kernel_parameters_file_name:
-          description:
-            Name of the kernel-parameters file to extract and upload to the artifact repository from the
-            /boot directory of the image root.
+          description: Name of the kernel-parameters file to extract and upload to the artifact repository from the /boot directory of the image root.
           default: kernel-parameters
           example: kernel-parameters
           type: string
@@ -2252,14 +2194,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/JobStatuses'
         artifact_id:
-          description: 'IMS artifact_id which specifies
-            the recipe (create job_type) or the image (customize job_type)
-            to fetch from the artifact repository.'
+          description: IMS artifact_id which specifies the recipe (create job_type) or the image (customize job_type) to fetch from the artifact repository.
           example: 46a2731e-a1d0-4f98-ba92-4f78c756bb12
           format: uuid
           type: string
         public_key_id:
-          description: Public key to use to enable passwordless ssh shells
+          description: Public key to use to enable passwordless SSH shells
           example: b05c54e3-9fc2-472d-b120-4fd718ff90aa
           format: uuid
           type: string
@@ -2279,9 +2219,7 @@ components:
           readOnly: true
           type: string
         ssh_containers:
-          description: >-
-            list of ssh containers used to customize images being built or
-            modified
+          description: List of SSH containers used to customize images being built or modified
           type: array
           items:
             $ref: '#/components/schemas/SshContainer'


### PR DESCRIPTION
## Summary and Scope

I discovered when working in the Cray CLI repo that the IMS API spec file there was out of date. In the process of correcting that, I discovered that the IMS spec file here in the repo has some incorrect information in it -- that is, the actual behavior of the IMS service does not match what is currently in the spec file.

While updating the spec file to correct the above, I also did some small linting of the formatting and language, mainly to try and make it more consistent.

There are no functional changes from this PR -- it is purely intended to make the API spec match the API behavior.

## Issues and Related PRs

* [Corresponding PR in the Cray CLI repo](https://github.com/Cray-HPE/craycli/pull/66) to update the IMS spec file there as well

## Testing

I ran the API spec validation tool documented in the IMS repo README file and it passes. I've also build a version of the Cray CLI based on it, and all of the CLI tests pass using it.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
