### PR TITLE
CASMCMS-8227 - Add platform and dkms information to data classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ myimage.yaml
 /.venv
 /ansible.cfg
 *.pyc
+.version
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8227 - Add platform support to image, recipe, and job objects.
+- CASMCMS-8370 - Add argument to recipe patch to allow changing template-parameters values.
+
 ### Changed
 - CASMCMS-8382 - Correct openapi.yaml to match actual API behavior. Linting of language and formatting of same.
+
+## [3.8.3] - 2023-01-06
+### Changed
+- Correct authentication
 
 ## [3.8.2] - 2022-12-22
 ### Changed

--- a/README.md
+++ b/README.md
@@ -145,9 +145,11 @@ The following are required:
    ```
    $ docker pull minio/minio
    
-   $ docker run -p 9000:9000,9001:9001 -d minio/minio server /data --console-address :9001
+   $ docker run -p 9000:9000 -p 9001:9001 -d minio/minio server /data --console-address :9001
    941dbec66ecd9fe062a0fc99a2ac1e998e89abc72293d001dc4a484f7a9bc67a
    
+   NOTE: may need to run 'docker run -p 9000:9000,9001:9001 -d minio/minio server /data --console-address :9001' instead
+
    $ docker logs 941dbec66ecd9fe062a0fc99a2ac1e998e89abc72293d001dc4a484f7a9bc67a
    Endpoint:  http://172.17.0.2:9000  http://127.0.0.1:9000
    
@@ -170,34 +172,44 @@ The following are required:
 
 ## Building
 ```
-$ docker build -t ims-service:dev -f Dockerfile .
+$ docker build -t cray-ims-service:dev -f Dockerfile .
 ```
+
+NOTE: if base images are in artifactory.algol60.net, be sure to authenticate against the docker repo
+before trying to build:
+```
+$ docker login artifactory.algol60.net
+```
+See more information on authetication here:
+https://rndwiki-pro.its.hpecorp.net/display/CSMTemp/Client+Authentication#ClientAuthentication-SecurityConsiderations
 
 ## Running Locally
 
 The image can be run with the following command:
 
 ```bash
-$ docker run --rm --name ims-service \
-  -p 9000:9000 \
+$ docker run --rm --name cray-ims-service \
+  -p 9100:9000 \
   -e "S3_ACCESS_KEY=minioadmin" \
   -e "S3_SECRET_KEY=minioadmin" \
-  -e "S3_ENDPOINT=172.17.0.2:9000" \
+  -e "S3_CONNECT_TIMEOUT=30" \
+  -e "S3_READ_TIMEOUT=30" \
+  -e "S3_ENDPOINT=http://172.17.0.2:9000" \
   -e "S3_IMS_BUCKET=ims" \
   -e "S3_BOOT_IMAGES_BUCKET=boot-images" \
   -e "FLASK_ENV=staging" \
   -v ~/tmp/datastore:/var/ims/data \
-  ims-service:dev
+  cray-ims-service:dev
 ```
 
-This will start the IMS server on `http://localhost:9000`. An S3 instance is
+This will start the IMS server on `http://localhost:9100`. An S3 instance is
 required for the IMS server to do anything meaningful. See the [Configuration Options](#Configuration-Options)
 section for more information and further configuration possibilities.
 
 ```
-$ curl http://127.0.0.1:9000/images
+$ curl http://127.0.0.1:9100/images
 []
-$ curl http://127.0.0.1:9000/recipes
+$ curl http://127.0.0.1:9100/recipes
 []
 ```
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2026,6 +2026,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RecipeKeyValuePair'
+        platform:
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
+        require_dkms:
+          description: Whether to enable DKMS for the job
+          type: boolean
+          example: false
     DeletedRecipeRecord:
       description: A Deleted Recipe Record
       type: object
@@ -2062,6 +2073,17 @@ components:
             - packer
           example: kiwi-ng
           type: string
+        platform:
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
+        require_dkms:
+          description: Whether to enable DKMS for the job
+          type: boolean
+          example: false
         linux_distribution:
           description: Linux distribution being built
           enum:
@@ -2080,6 +2102,22 @@ components:
       properties:
         link:
           $ref: '#/components/schemas/ArtifactLinkRecord'
+        platform:
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
+        require_dkms:
+          description: Whether enable DKMS for the job
+          type: boolean
+          example: false
+        template_dictionary:
+          description: List of key/value pairs to be templated into the recipe when building the image.
+          type: array
+          items:
+            $ref: '#/components/schemas/RecipeKeyValuePair'
     ImageRecord:
       description: An Image Record
       type: object
@@ -2105,6 +2143,13 @@ components:
           minLength: 1
         link:
           $ref: '#/components/schemas/ArtifactLinkRecord'
+        platform:
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
     DeletedImageRecord:
       description: A Deleted Image Record
       type: object
@@ -2137,12 +2182,26 @@ components:
           minLength: 1
         link:
           $ref: '#/components/schemas/ArtifactLinkRecord'
+        platform:
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
     ImagePatchRecord:
       description: Values to update an ImageRecord with
       type: object
       properties:
         link:
           $ref: '#/components/schemas/ArtifactLinkRecord'
+        platform:
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
     JobRecord:
       description: A Job Record
       type: object
@@ -2244,6 +2303,18 @@ components:
           default: default
           type: string
           readOnly: true
+        platform:
+          readOnly: true
+          description: Target platform for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
+        require_dkms:
+          description: Whether enable DKMS for the job
+          type: boolean
+          example: false
     JobPatchRecord:
       description: Values to update a JobRecord with
       type: object

--- a/generate_test_data
+++ b/generate_test_data
@@ -30,7 +30,7 @@ import boto3 as boto3
 import requests
 from botocore.exceptions import ClientError
 
-IMS_SERVICE_URL = os.environ.get("IMS_SERVICE_URL", "http://localhost:5000")
+IMS_SERVICE_URL = os.environ.get("IMS_SERVICE_URL", "http://localhost:9100")
 
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "http://localhost:9000")
 S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", "minioadmin")
@@ -92,6 +92,9 @@ def generate_image_manifest(image_id, artifacts):
 
 
 def generate_ims_image():
+    # make sure the S3 bucket exists
+    generate_bucket(BOOT_IMAGES_BUCKET)
+
     result = requests.post(f'{IMS_SERVICE_URL}/images', json={'name': 'test'})
     result.raise_for_status()
     image = result.json()
@@ -112,6 +115,9 @@ def generate_ims_image():
 
 
 def generate_ims_recipe():
+    # Make sure the S3 bucket exists
+    generate_bucket(RECIPES_BUCKET)
+
     result = requests.post(f'{IMS_SERVICE_URL}/recipes',
                            json={'name': 'test', 'recipe_type': 'kiwi-ng', 'linux_distribution': 'sles15'})
     result.raise_for_status()
@@ -124,6 +130,17 @@ def generate_ims_recipe():
     result.raise_for_status()
     return result.json()
 
+# Make sure bucket exists
+def generate_bucket(bucket_name):
+    try:
+        bucket = s3.Bucket(bucket_name)
+        if bucket.creation_date:
+            print(f"Bucket {bucket_name} exists.")
+        else:
+            print(f"Bucket {bucket_name} does not exist - creating...")
+            s3.create_bucket(Bucket=bucket_name)
+    except ClientError as err:
+        raise
 
 def main():
     from pprint import pprint
@@ -131,7 +148,6 @@ def main():
     pprint(generate_ims_recipe())
     print("Image:")
     pprint(generate_ims_image())
-
 
 if __name__ == "__main__":
     main()

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -39,6 +39,7 @@ data:
   JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL: "{{ .Values.customer_access.access_pool }}"
   JOB_ENABLE_DKMS: "{{ .Values.jobs.enable_dkms }}"
   JOB_KATA_RUNTIME: "{{ .Values.jobs.kata_runtime }}"
+  JOB_AARCH64_RUNTIME: "{{ .Values.jobs.aarch64_runtime }}"
 
   S3_IMS_BUCKET: "{{ .Values.s3.ims_bucket }}"
   S3_BOOT_IMAGES_BUCKET: "{{ .Values.s3.boot_images_bucket }}"

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -153,6 +153,8 @@ data:
               value: '/etc/admin-client-auth'
             - name: IMS_JOB_ID
               value: "$id"
+            - name: BUILD_PLATFORM
+              value: "$job_platform"
             volumeMounts:
             - name: ca-rpm-vol
               mountPath: /mnt/ca-rpm
@@ -205,6 +207,10 @@ data:
               value: "$id"
             - name: JOB_ENABLE_DKMS
               value: "$job_enable_dkms"
+            - name: BUILD_PLATFORM
+              value: "$job_platform"
+            - name: IMS_ARM_BUILDER
+              value: "{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}-arm64"
             volumeMounts:
             - name: recipe-vol
               mountPath: /mnt/recipe

--- a/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
+++ b/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
@@ -49,9 +49,34 @@ spec:
               cp /var/ims/data/v2_recipes.json /var/ims/data/v2.1_recipes.json
             fi
 
+            if [[ -f /var/ims/data/v2.1_recipes.json ]] && [[ ! -f /var/ims/data/v2.2_recipes.json ]]
+            then
+              cp /var/ims/data/v2.1_recipes.json /var/ims/data/v2.2_recipes.json
+            fi
+
             if [[ -f /var/ims/data/v3_deleted_recipes.json ]] && [[ ! -f /var/ims/data/v3.1_deleted_recipes.json ]]
             then
               cp /var/ims/data/v3_deleted_recipes.json /var/ims/data/v3.1_deleted_recipes.json
+            fi
+
+            if [[ -f /var/ims/data/v3.1_deleted_recipes.json ]] && [[ ! -f /var/ims/data/v3.2_deleted_recipes.json ]]
+            then
+              cp /var/ims/data/v3.1_deleted_recipes.json /var/ims/data/v3.2_deleted_recipes.json
+            fi
+
+            if [[ -f /var/ims/data/v2_images.json ]] && [[ ! -f /var/ims/data/v2.1_images.json ]]
+            then
+              cp /var/ims/data/v2_images.json /var/ims/data/v2.1_images.json
+            fi
+
+            if [[ -f /var/ims/data/v3_deleted_images.json ]] && [[ ! -f /var/ims/data/v3.1_deleted_images.json ]]
+            then
+              cp /var/ims/data/v3_deleted_images.json /var/ims/data/v3.1_deleted_images.json
+            fi
+
+            if [[ -f /var/ims/data/v2_jobs.json ]] && [[ ! -f /var/ims/data/v2.1_jobs.json ]]
+            then
+              cp /var/ims/data/v2_jobs.json /var/ims/data/v2.1_jobs.json
             fi
 
             chown -Rv 65534:65534 /var/ims/data

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -90,6 +90,7 @@ customer_access:
 jobs:
   enable_dkms: false
   kata_runtime: "kata-qemu"
+  aarch64_runtime: "kata-qeum-aarch64"
 
 cray-service:
   type: Deployment

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -30,7 +30,6 @@ import collections
 import os
 import os.path
 
-
 class DataStoreHACK(collections.MutableMapping):
     """ A dictionary that reads/writes to a file """
 
@@ -49,8 +48,10 @@ class DataStoreHACK(collections.MutableMapping):
 
     def _read(self):
         """ Read in the data """
+        # Setting 'unknown="Exclude" allows downgrades by just dropping any data
+        # fields that are no longer part of the current schema.
         with open(self.store_file, 'r') as data_file:
-            obj_data = self.schema.loads(data_file.read(), many=True)
+            obj_data = self.schema.loads(data_file.read(), many=True, unknown="EXCLUDE")
             self.store = {str(getattr(obj, self.key_field)): obj for obj in obj_data}
 
     def _write(self):

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -60,21 +60,21 @@ def load_datastore(_app):
         V3DeletedPublicKeyRecordSchema(), 'id')
 
     _app.data['recipes'] = DataStoreHACK(
-        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.1_recipes.json'),
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.2_recipes.json'),
         V2RecipeRecordSchema(), 'id')
     _app.data['deleted_recipes'] = DataStoreHACK(
-        os.path.join(_app.config['HACK_DATA_STORE'], 'v3.1_deleted_recipes.json'),
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v3.2_deleted_recipes.json'),
         V3DeletedRecipeRecordSchema(), 'id')
 
     _app.data['images'] = DataStoreHACK(
-        os.path.join(_app.config['HACK_DATA_STORE'], 'v2_images.json'),
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.1_images.json'),
         V2ImageRecordSchema(), 'id')
     _app.data['deleted_images'] = DataStoreHACK(
-        os.path.join(_app.config['HACK_DATA_STORE'], 'v3_deleted_images.json'),
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v3.1_deleted_images.json'),
         V3DeletedImageRecordSchema(), 'id')
 
     _app.data['jobs'] = DataStoreHACK(
-        os.path.join(_app.config['HACK_DATA_STORE'], 'v2_jobs.json'),
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.1_jobs.json'),
         V2JobRecordSchema(), 'id')
 
 

--- a/src/server/models/images.py
+++ b/src/server/models/images.py
@@ -29,19 +29,22 @@ import datetime
 import uuid
 
 from marshmallow import Schema, fields, post_load, RAISE
-from marshmallow.validate import Length
+from marshmallow.validate import Length, OneOf
 
 from src.server.models import ArtifactLink
-
+from src.server.helper import PLATFORM_X86_64, PLATFORM_ARM64
 
 class V2ImageRecord:
     """ The ImageRecord object """
 
     # pylint: disable=W0622
-    def __init__(self, name, link=None, id=None, created=None):
+    def __init__(self, name, link=None, id=None, created=None, platform=PLATFORM_X86_64):
         # Supplied
         self.name = name
         self.link = link
+        
+        # v2.1
+        self.platform = platform
 
         # derived
         self.id = id or uuid.uuid4()
@@ -57,6 +60,8 @@ class V2ImageRecordInputSchema(Schema):
                       validate=Length(min=1, error="name field must not be blank"))
     link = fields.Nested(ArtifactLink, required=False, allow_none=True,
                          description="the location of the image manifest")
+    platform = fields.Str(required=False, default = PLATFORM_X86_64, description="Architecture of the image",
+                          validate=OneOf([PLATFORM_ARM64,PLATFORM_X86_64]), load_default=True, dump_default=True)
 
     @post_load
     def make_image(self, data):
@@ -82,5 +87,8 @@ class V2ImageRecordPatchSchema(Schema):
     """
     Schema for a updating an ImageRecord object.
     """
-    link = fields.Nested(ArtifactLink, required=True, allow_none=False,
+    link = fields.Nested(ArtifactLink, required=False, allow_none=False,
                          description="the location of the image manifest")
+    platform = fields.Str(required=False, description="Architecture of the recipe", default=PLATFORM_X86_64,
+                          validate=OneOf([PLATFORM_ARM64,PLATFORM_X86_64]), load_default=True, dump_default=True)
+

--- a/src/server/v2/resources/images.py
+++ b/src/server/v2/resources/images.py
@@ -226,8 +226,11 @@ class V2ImageResource(V2BaseImageResource):
                     if problem:
                         current_app.logger.info("%s Could not validate link artifact or artifact doesn't exist", log_id)
                         return problem
+            elif key == "platform":
+                current_app.logger.info(f"Patching platform with {value}")
+                image.platform = value
             else:
-                current_app.logger.info("%s Not able to patch record field {} with value {}", log_id, key, value)
+                current_app.logger.info(f"{log_id} Not able to patch record field {key} with value {value}")
                 return generate_data_validation_failure(errors=[])
 
             setattr(image, key, value)

--- a/src/server/v2/resources/recipes.py
+++ b/src/server/v2/resources/recipes.py
@@ -209,8 +209,14 @@ class V2RecipeResource(Resource):
                         validate_artifact(value)
                     except ImsArtifactValidationException as exc:
                         return problemify(status=http.client.UNPROCESSABLE_ENTITY, detail=str(exc))
+            elif key == 'platform':
+                recipe.platform = value
+            elif key == 'require_dkms':
+                recipe.require_dkms = value
+            elif key == 'template_dictionary':
+                recipe.template_dictionary = dict(value)
             else:
-                current_app.logger.info("%s Not able to patch record field {} with value {}", log_id, key, value)
+                current_app.logger.info(f"{log_id} Not able to patch record field {key} with value {value}")
                 return generate_data_validation_failure(errors=[])
 
             setattr(recipe, key, value)

--- a/src/server/v3/models/images.py
+++ b/src/server/v3/models/images.py
@@ -34,10 +34,10 @@ class V3DeletedImageRecord(V2ImageRecord):
     """ The ImageRecord object """
 
     # pylint: disable=W0622
-    def __init__(self, name, link=None, id=None, created=None, deleted=None):
+    def __init__(self, name, link=None, id=None, created=None, deleted=None, platform="x86_64"):
         # Supplied
         self.deleted = deleted or datetime.datetime.now()
-        super().__init__(name, link=link, id=id, created=created)
+        super().__init__(name, link=link, id=id, created=created, platform=platform)
 
     def __repr__(self):
         return '<V3DeletedImageRecord(id={self.id!r})>'.format(self=self)

--- a/src/server/v3/models/recipes.py
+++ b/src/server/v3/models/recipes.py
@@ -29,6 +29,7 @@ from marshmallow.validate import OneOf
 
 from src.server.models.recipes import V2RecipeRecordInputSchema, V2RecipeRecord
 from src.server.v3.models import PATCH_OPERATIONS
+from src.server.helper import PLATFORM_X86_64, PLATFORM_ARM64
 
 
 class V3DeletedRecipeRecord(V2RecipeRecord):
@@ -36,11 +37,13 @@ class V3DeletedRecipeRecord(V2RecipeRecord):
 
     # pylint: disable=W0622
     def __init__(self, name, recipe_type, linux_distribution,
-                 link=None, id=None, created=None, deleted=None, template_dictionary=None):
+                 link=None, id=None, created=None, deleted=None,
+                 template_dictionary=None, require_dkms=False, platform=PLATFORM_X86_64):
         # Supplied
         self.deleted = deleted or datetime.datetime.now()
         super().__init__(name, recipe_type=recipe_type, linux_distribution=linux_distribution,
-                         link=link, id=id, created=created, template_dictionary=template_dictionary)
+                         link=link, id=id, created=created, template_dictionary=template_dictionary,
+                         require_dkms=require_dkms, platform=platform)
 
     def __repr__(self):
         return '<V3DeletedRecipeRecord(id={self.id!r})>'.format(self=self)

--- a/src/server/v3/resources/images.py
+++ b/src/server/v3/resources/images.py
@@ -373,9 +373,11 @@ class V3ImageResource(V3BaseImageResource):
                         current_app.logger.info(f"The artifact {value} is not in S3 and "
                                                 f"was not soft-deleted. Ignoring")
                         current_app.logger.info(str(exc))
-
+            elif key == "platform":
+                current_app.logger.info(f"Patching platform with {value}")
+                image.platform = value
             else:
-                current_app.logger.info("%s Not able to patch record field {} with value {}", log_id, key, value)
+                current_app.logger.info(f"{log_id} Not able to patch record field {key} with value {value}")
                 return generate_data_validation_failure(errors=[])
 
             setattr(image, key, value)

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -47,7 +47,7 @@ from src.server.errors import problemify, generate_missing_input_response, gener
     generate_resource_not_found_response
 from src.server.helper import validate_artifact, get_log_id, get_download_url, read_manifest_json, \
     IMAGE_MANIFEST_VERSION_1_0, IMAGE_MANIFEST_VERSION, IMAGE_MANIFEST_ARTIFACTS, IMAGE_MANIFEST_ARTIFACT_TYPE, \
-    IMAGE_MANIFEST_ARTIFACT_TYPE_SQUASHFS, ARTIFACT_LINK
+    IMAGE_MANIFEST_ARTIFACT_TYPE_SQUASHFS, ARTIFACT_LINK, PLATFORM_ARM64, PLATFORM_X86_64
 from src.server.models.jobs import V2JobRecordInputSchema, V2JobRecordSchema, V2JobRecordPatchSchema, \
     JOB_TYPE_CREATE, JOB_TYPE_CUSTOMIZE, JOB_TYPES, STATUS_TYPES, JOB_STATUS_ERROR, JOB_STATUS_SUCCESS
 
@@ -88,6 +88,7 @@ class V3BaseJobResource(Resource):
         
         # NOTE: make sure this isn't a non-zero length string of spaces
         self.job_kata_runtime = os.getenv("JOB_KATA_RUNTIME", "kata-qemu").strip()
+        self.job_aarch64_runtime = os.getenv("JOB_AARCH64_RUNTIME", "kata-qemu-aarch64").strip()
 
     def _create_namespaced_destination_rule(self, namespace):
         """ Helper routine to create a partial function to create a new ISTIO destination rule. """
@@ -327,6 +328,7 @@ class V3JobCollection(V3BaseJobResource):
         """
 
         def _retrieve_recipe_record():
+            current_app.logger.info(f"Retrieving recipe info")
             recipe_record = current_app.data['recipes'].get(str(artifact_id))
             if not recipe_record:
                 current_app.logger.info("%s no IMS recipe record matches artifact_id=%s", log_id, artifact_id)
@@ -348,6 +350,7 @@ class V3JobCollection(V3BaseJobResource):
             return recipe_record, None
 
         def _retrieve_image_record():
+            current_app.logger.info(f"Retrieving image info")
             image_record = current_app.data['images'].get(str(artifact_id))
             if not image_record:
                 current_app.logger.info("%s no IMS image record matches artifact_id=%s", log_id, artifact_id)
@@ -556,15 +559,23 @@ class V3JobCollection(V3BaseJobResource):
 
         current_app.logger.info("%s json_data = %s", log_id, json_data)
 
+        # keep track of optional user input values
+        userSpecifiedDKMS = None
+        if 'require_dkms' in json_data:
+            userSpecifiedDKMS = json_data['require_dkms']
+
         # Validate input
+        current_app.logger.info(f"About to validate schema...")
         errors = job_user_input_schema.validate(json_data)
+        current_app.logger.info(f" validated schema")
         if errors:
             current_app.logger.info("%s There was a problem validating the post data: %s", log_id, errors)
             return generate_data_validation_failure(errors)
 
-        # Create a job record if the user input data was valid
+        # Create a job record and populate with user input data
         new_job = job_schema.load(json_data)
 
+        # fill in job information based on job type
         if new_job.job_type == JOB_TYPE_CREATE:
             current_app.logger.debug("%s Processing create request", log_id)
 
@@ -607,13 +618,30 @@ class V3JobCollection(V3BaseJobResource):
                                      'invalid and then re-run the request with valid information.')
 
         # The artifact info consists of the artifact record, a download URL and the md5sum (if available) of the file.
+        # Get the information on the artifact being used for the job
         artifact_info, problem = V3JobCollection.get_artifact_info(new_job.job_type, log_id, new_job.artifact_id)
         if problem:
             current_app.logger.info("%s Could not get download url for artifact", log_id)
             return problem
-
         artifact_record = artifact_info["artifact"]  # pylint: disable=unsubscriptable-object
 
+        current_app.logger.info(f"ARTIFACT_RECORD: {artifact_record}")
+
+        # both images and recipes have a platform specified - shift into the job
+        new_job.platform = artifact_record.platform
+        current_app.logger.info(f"PLATFORM: {new_job.platform}")
+
+        # Determine cases where the dkms security settings are required without user specifying
+        if new_job.platform == PLATFORM_ARM64:
+           # If the platform is aarch64, then the dkms settings are required
+            current_app.logger.info(f" NOTE: aarch64 platform requires dkms")
+            new_job.require_dkms = True
+        elif new_job.job_type == JOB_TYPE_CREATE and artifact_record.require_dkms and userSpecifiedDKMS==None:
+            # Let the setting from the recipe flow through if the user has not specified otherwise
+            current_app.logger.info(f"Overriding require_dkms based on recipe setting")
+            new_job.require_dkms = True
+
+        # get the public key information
         public_key_data, problem = V3JobCollection.get_public_key_data(log_id, new_job.public_key_id)
         if problem:
             current_app.logger.info("%s Could not get download url for artifact", log_id)
@@ -621,18 +649,24 @@ class V3JobCollection(V3BaseJobResource):
 
         external_dns_hostname = f"{str(new_job.id).lower()}.ims.{self.job_customer_access_subnet_name}.{self.job_customer_access_network_domain}"
 
+        current_app.logger.info(f"INFORMATION:: new_job: {new_job}")
+
         # switch the set of values depending on if the kata-qemu runtime class is used
         job_enable_dkms = "False"
         job_runtime_class = ""
         job_service_account = ""
         job_security_privilege = "false"
         job_security_capabilities = ""
-        if self.job_enable_dkms:
+        if new_job.require_dkms:
             job_enable_dkms = "True"
             job_runtime_class = self.job_kata_runtime if "kata" in self.job_kata_runtime else "kata-qemu"
             job_service_account = "ims-service-job-mount"
             job_security_privilege = "true"
             job_security_capabilities = "SYS_ADMIN"
+
+        # aarch64 platform needs dkms, plus its own runtime class
+        if new_job.platform == PLATFORM_ARM64:
+            job_runtime_class = self.job_aarch64_runtime
 
         # set up the template params to feed into the job template
         template_params = {
@@ -665,6 +699,8 @@ class V3JobCollection(V3BaseJobResource):
             template_params["template_dictionary"] = \
                 json.dumps({r['key']: r['value'] for r in artifact_record.template_dictionary})
             template_params["recipe_type"] = artifact_record.recipe_type
+
+        current_app.logger.info(f"Template arguments: {template_params}")
 
         new_job, problem = self.create_kubernetes_resources(
             log_id, new_job, template_params,

--- a/src/server/v3/resources/recipes.py
+++ b/src/server/v3/resources/recipes.py
@@ -246,6 +246,12 @@ class V3RecipeResource(V3BaseRecipeCollection):
                         validate_artifact(value)
                     except ImsArtifactValidationException as exc:
                         return problemify(status=http.client.UNPROCESSABLE_ENTITY, detail=str(exc))
+            elif key == 'platform':
+                recipe.platform = value
+            elif key == 'require_dkms':
+                recipe.require_dkms = value
+            elif key == 'template_dictionary':
+                recipe.template_dictionary = dict(value)
             else:
                 current_app.logger.info("%s Not able to patch record field {} with value {}", log_id, key, value)
                 return generate_data_validation_failure(errors=[])
@@ -450,7 +456,7 @@ class V3DeletedRecipeResource(V3BaseRecipeCollection):
                     current_app.logger.info("%s Unsupported patch operation value %s.", log_id, value)
                     return generate_data_validation_failure(errors=[])
             else:
-                current_app.logger.info('%s Unsupported patch request key="%s" value="%s"', log_id, key, value)
+                current_app.logger.info(f"{log_id} Unsupported patch request key={key} value={value}")
                 return generate_data_validation_failure(errors=[])
 
         return None, 204

--- a/tests/v2/test_v2_images.py
+++ b/tests/v2/test_v2_images.py
@@ -55,6 +55,7 @@ class TestV2ImageEndpoint(TestCase):
         self.test_id = str(uuid.uuid4())
         self.test_id_link_none = str(uuid.uuid4())
         self.test_id_no_link = str(uuid.uuid4())
+        self.test_platform = "x86_64"
         self.app = self.useFixture(V2FlaskTestClientFixture()).client
         self.data_record_with_link = {
             'name': self.getUniqueString(),
@@ -65,17 +66,20 @@ class TestV2ImageEndpoint(TestCase):
             },
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_id,
+            'platform': self.test_platform,
         }
         self.data_record_link_none = {
             'name': self.getUniqueString(),
             'link': None,
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_id_link_none,
+            'platform': self.test_platform,
         }
         self.data_record_no_link = {
             'name': self.getUniqueString(),
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_id_no_link,
+            'platform': self.test_platform,
         }
         self.data = [
             self.data_record_with_link,
@@ -333,6 +337,32 @@ class TestV2ImageEndpoint(TestCase):
                 self.assertEqual(response_data[key], self.data_record_with_link[key],
                                  'resource field "{}" returned was not equal'.format(key))
 
+    def test_patch_change_platform(self):
+        """ Test that we're able to patch a record with a new platform"""
+        
+        platforms = ['x86_64','aarch64','x86_64']
+        for platform in platforms:
+            patch_data = {'platform': platform}
+            response = self.app.patch(self.test_uri_link_none, content_type='application/json', data=json.dumps(patch_data))
+
+            self.assertEqual(response.status_code, 200, 'status code was not 200')
+            response_data = json.loads(response.data)
+            self.assertEqual(set(self.data_record_link_none.keys()).difference(response_data.keys()), set(),
+                            'returned keys not the same')
+            for key in response_data:
+                if key == 'created':
+                    # microseconds don't always match up
+                    self.assertAlmostEqual(datetime.datetime.strptime(self.data_record_link_none[key],
+                                                                    '%Y-%m-%dT%H:%M:%S'),
+                                        datetime.datetime.strptime(response_data['created'],
+                                                                    '%Y-%m-%dT%H:%M:%S+00:00'),
+                                        delta=datetime.timedelta(seconds=5))
+                elif key == 'platform':
+                    self.assertEqual(response_data[key], patch_data['platform'],
+                                    'resource field "{}" returned was not equal'.format(key))
+                else:
+                    self.assertEqual(response_data[key], self.data_record_link_none[key],
+                                    'resource field "{}" returned was not equal'.format(key))
 
 class TestV2ImagesCollectionEndpoint(TestCase):
     """
@@ -348,6 +378,7 @@ class TestV2ImagesCollectionEndpoint(TestCase):
         self.test_uri = '/images'
         self.app = self.useFixture(V2FlaskTestClientFixture()).client
         self.test_id = str(uuid.uuid4())
+        self.test_platform = "x86_64"
         self.data = {
             'name': self.getUniqueString(),
             'link': {
@@ -357,6 +388,7 @@ class TestV2ImagesCollectionEndpoint(TestCase):
             },
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_id,
+            'platform': self.test_platform,
         }
         self.test_images = self.useFixture(V2ImagesDataFixture(initial_data=self.data)).datastore
         self.test_domain = 'https://api-gw-service-nmn.local'
@@ -437,7 +469,7 @@ class TestV2ImagesCollectionEndpoint(TestCase):
                          r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z')
         self.assertIsNotNone(response_data['created'], 'image creation date/time was not set properly')
         self.assertItemsEqual(response_data.keys(),
-                              ['created', 'name', 'link', 'id'],
+                              ['created', 'name', 'link', 'id', 'platform'],
                               'returned keys not the same')
 
     def test_post_link_none(self):
@@ -456,7 +488,7 @@ class TestV2ImagesCollectionEndpoint(TestCase):
                          r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z')
         self.assertIsNotNone(response_data['created'], 'image creation date/time was not set properly')
         self.assertItemsEqual(response_data.keys(),
-                              ['created', 'name', 'link', 'id'],
+                              ['created', 'name', 'link', 'id', 'platform'],
                               'returned keys not the same')
 
     def test_post_no_link(self):
@@ -474,7 +506,7 @@ class TestV2ImagesCollectionEndpoint(TestCase):
                          r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z')
         self.assertIsNotNone(response_data['created'], 'image creation date/time was not set properly')
         self.assertItemsEqual(response_data.keys(),
-                              ['created', 'name', 'link', 'id'],
+                              ['created', 'name', 'link', 'id', 'platform'],
                               'returned keys not the same')
 
     def test_post_400_no_input(self):

--- a/tests/v2/test_v2_jobs.py
+++ b/tests/v2/test_v2_jobs.py
@@ -63,6 +63,8 @@ class TestV2JobEndpoint(TestCase):
         super(TestV2JobEndpoint, self).setUp()
         self.app = self.useFixture(V2FlaskTestClientFixture()).client
         self.test_job_id = str(uuid.uuid4())
+        self.test_platform = "x86_64"
+        self.test_require_dkms = False
         self.data = {
             'job_type': "create",
             'artifact_id': str(uuid.uuid4()),
@@ -76,6 +78,8 @@ class TestV2JobEndpoint(TestCase):
             'kubernetes_job': 'cray-ims-%s-create' % self.test_job_id,
             'kubernetes_service': 'cray-ims-%s-service' % self.test_job_id,
             'kubernetes_configmap': 'cray-ims-%s-configmap' % self.test_job_id,
+            'platform': self.test_platform,
+            'require_dkms': self.test_require_dkms,
         }
         self.useFixture(V2JobsDataFixture(initial_data=self.data))
         self.test_uri = '/jobs/{}'.format(self.data['id'])
@@ -185,6 +189,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
         self.test_recipe_id = str(uuid.uuid4())
         self.test_image_id = str(uuid.uuid4())
         self.test_public_key_id = str(uuid.uuid4())
+        self.test_platform = "x86_64"
+        self.test_require_dkms = False
         self.today = datetime.datetime.now().replace(microsecond=0)
         self.week_ago = self.today - datetime.timedelta(days=7)
         self.recipe_data = {
@@ -198,6 +204,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
             },
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_recipe_id,
+            'platform': self.test_platform,
+            'require_dkms': self.test_require_dkms,
         }
         self.image_data = {
             'name': 'cray_sles12sp3_barebones',
@@ -208,6 +216,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
             },
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_image_id,
+            'platform': self.test_platform,
         }
         self.job_data = {
             'job_type': "create",
@@ -219,6 +228,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
             'initrd_file_name': self.getUniqueString(),
             'created': self.week_ago.isoformat(),
             'id': str(uuid.uuid4()),
+            'platform': self.test_platform,
+            'require_dkms': self.test_require_dkms,
         }
         self.public_key_data = {
             'name': str(uuid.uuid4()),
@@ -415,7 +426,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -480,7 +491,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -529,7 +540,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     def test_post_create_with_ssh_container(self, utils_mock, config_mock, client_mock):
@@ -627,7 +638,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     @responses.activate
@@ -731,7 +742,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     def test_post_create_with_multiple_ssh_containers(self, utils_mock, config_mock, client_mock):

--- a/tests/v3/test_v3_deleted_images.py
+++ b/tests/v3/test_v3_deleted_images.py
@@ -78,6 +78,7 @@ class TestV3BaseDeletedImage(TestCase):
         self.test_with_link_record = {
             'id': self.test_with_link_id,
             'name': self.getUniqueString(),
+            'platform': "x86_64",
             'link': {
                 'path': 's3://boot-images/{}/manifest.json'.format(self.test_with_link_id),
                 'etag': self.getUniqueString(),
@@ -92,6 +93,7 @@ class TestV3BaseDeletedImage(TestCase):
         self.test_no_link_record = {
             'id': self.test_no_link_id,
             'name': self.getUniqueString(),
+            'platform': "x86_64",
             'link': None,
             'created': (datetime.now() - timedelta(days=77)).replace(microsecond=0).isoformat(),
             'deleted': datetime.now().replace(microsecond=0).isoformat(),

--- a/tests/v3/test_v3_deleted_recipes.py
+++ b/tests/v3/test_v3_deleted_recipes.py
@@ -50,6 +50,8 @@ class TestV3DeletedRecipeBase(TestCase):
 
         self.input_recipe_type = 'kiwi-ng'
         self.input_linux_distribution = 'sles12'
+        self.input_platform = 'x86_64'
+        self.input_require_dkms = False
 
         self.test_with_link_id = str(uuid4())
         self.test_with_link_uri = f'/v3/deleted/recipes/{self.test_with_link_id}'
@@ -62,6 +64,8 @@ class TestV3DeletedRecipeBase(TestCase):
             },
             'recipe_type': self.input_recipe_type,
             'linux_distribution': self.input_linux_distribution,
+            'platform': self.input_platform,
+            'require_dkms': self.input_require_dkms,
             'template_dictionary': [],
             'created': (datetime.now() - timedelta(days=77)).replace(microsecond=0).isoformat(),
             'deleted': datetime.now().replace(microsecond=0).isoformat(),
@@ -79,6 +83,8 @@ class TestV3DeletedRecipeBase(TestCase):
             'created': (datetime.now() - timedelta(days=77)).replace(microsecond=0).isoformat(),
             'deleted': datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_link_none_id,
+            'platform': self.input_platform,
+            'require_dkms': self.input_require_dkms,
         }
 
         self.test_no_link_id = str(uuid4())
@@ -92,6 +98,8 @@ class TestV3DeletedRecipeBase(TestCase):
             'created': (datetime.now() - timedelta(days=77)).replace(microsecond=0).isoformat(),
             'deleted': datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_no_link_id,
+            'platform': self.input_platform,
+            'require_dkms': self.input_require_dkms,
         }
         self.data = [
             self.test_with_link_record,

--- a/tests/v3/test_v3_jobs.py
+++ b/tests/v3/test_v3_jobs.py
@@ -76,6 +76,8 @@ class TestV3JobEndpoint(TestCase):
             'kubernetes_job': 'cray-ims-%s-create' % self.test_job_id,
             'kubernetes_service': 'cray-ims-%s-service' % self.test_job_id,
             'kubernetes_configmap': 'cray-ims-%s-configmap' % self.test_job_id,
+            'platform': "x86_64",
+            'require_dkms': False,
         }
         self.useFixture(V2JobsDataFixture(initial_data=self.data))
         self.test_uri = '/jobs/{}'.format(self.data['id'])
@@ -198,6 +200,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
             },
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_recipe_id,
+            'platform': "x86_64",
+            'require_dkms': False,
         }
         self.image_data = {
             'name': 'cray_sles12sp3_barebones',
@@ -208,6 +212,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
             },
             'created': datetime.datetime.now().replace(microsecond=0).isoformat(),
             'id': self.test_image_id,
+            'platform': "x86_64",
         }
         self.job_data = {
             'job_type': "create",
@@ -219,6 +224,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
             'initrd_file_name': self.getUniqueString(),
             'created': self.week_ago.isoformat(),
             'id': str(uuid.uuid4()),
+            'platform': "x86_64",
+            'require_dkms': False,
         }
         self.public_key_data = {
             'name': str(uuid.uuid4()),
@@ -415,7 +422,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name','platform', 'require_dkms'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -480,7 +487,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name','platform', 'require_dkms'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -529,7 +536,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     def test_post_create_with_ssh_container(self, utils_mock, config_mock, client_mock):
@@ -627,7 +634,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     @responses.activate
@@ -731,7 +738,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name'],
+                               'kernel_parameters_file_name', 'platform', 'require_dkms'],
                               'returned keys not the same')
 
     def test_post_create_with_multiple_ssh_containers(self, utils_mock, config_mock, client_mock):


### PR DESCRIPTION
## Summary and Scope

Add the platform and dkms information to image, recipe, and job objects. The jobs will be automatically configured to run with or without dkms enabled, and on the correct platform based on the information in the image/recipe being used.

This also includes a change to allow modification of the template-parameters dictionary in recipes. It was allowed to be set on initial creation of the recipe, but the user was not able to modify these later.

There are changes to the unit tests to adapt to the new parameters as well as new tests to verify changing them works. 

## Issues and Related PRs
* Resolves [CASMCMS-8227](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8227)
* Resolves [CASMCMS-8370](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8370)

## Testing
### Tested on:
  * `Surtur`
  * Local development environment
  * Unit tests

### Test description:

The new version was installed via helm on Surtur, and a new craycli was installed into a local python virtual env. I tested the new options with setting / changing record values and kicking off new jobs to insure the correct parameters were picked up. Julian is continuing to use this as the platform for getting arm64 jobs working.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a fairly large change but will continue to be tested before being added to the release.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

