### PR TITLE
CASMCMS-8459 - add job platform information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CASMCMS-8227 - Add platform support to image, recipe, and job objects.
 - CASMCMS-8370 - Add argument to recipe patch to allow changing template-parameters values.
+- CASMCMS-8459 - Add platform argument through job templates.
 
 ### Changed
 - CASMCMS-8382 - Correct openapi.yaml to match actual API behavior. Linting of language and formatting of same.

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -268,6 +268,8 @@ data:
               value: "$id"
             - name: SSH_JAIL
               value: "$ssh_jail"
+            - name: BUILD_PLATFORM
+              value: "$job_platform"
             - name: S3_BUCKET
               value: "$s3_bucket"
             - name: S3_ACCESS_KEY

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -690,7 +690,8 @@ class V3JobCollection(V3BaseJobResource):
             "runtime_class": job_runtime_class,
             "service_account": job_service_account,
             "security_privilege": job_security_privilege,
-            "security_capabilites": job_security_capabilities
+            "security_capabilites": job_security_capabilities,
+            "job_platform": new_job.platform
         }
 
         current_app.logger.info(f"Job template param: {template_params}")


### PR DESCRIPTION
## Summary and Scope

Missed passing the job platform variable through to the template params in the v3 version and add to the buildenv sidecar container.

## Issues and Related PRs

* Resolves [CASMCMS-8459](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8459)

## Testing
### Tested on:

  * `Mug`

### Test description:

In upgraded ims via helm and ran build and customize jobs with the new params. I verified the templating worked and the jobs were set up and ran correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - fixing an error from the last larger change set.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

