### PR TITLE
Fix IMS_ARM_BUILDER env var in kiwi build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8227 - Add platform support to image, recipe, and job objects.
 - CASMCMS-8370 - Add argument to recipe patch to allow changing template-parameters values.
 - CASMCMS-8459 - Add platform argument through job templates, fixes for arm64 builds.
-- CASMCMS-8595 - rename platform to arch
+- CASMCMS-8595 - rename platform to arch, fix kiwi env var.
 
 ## [3.8.3] - 2023-01-06
 ### Changed

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -210,7 +210,7 @@ data:
             - name: BUILD_ARCH
               value: "$job_arch"
             - name: IMS_ARM_BUILDER
-              value: "{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}-arm64"
+              value: "{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}"
             volumeMounts:
             - name: recipe-vol
               mountPath: /mnt/recipe


### PR DESCRIPTION
## Summary and Scope

Quick fix for the env var in kiwi builder template to get the correct arm64 builder image.

## Testing
### Tested on:
  * `Mug`

### Test description:

Hand-edited the template config map to the correct value and arm64 recipes build as they should.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? n
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - slight fix to image name.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

