### PR TITLE
CASMCMS-8567 - support arm64 image customization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [3.9.1] - 2023-05-17
+### Changed
+- CASMCMS-8567 - Support arm64 image customization.
+
 ## [3.9.0] - 2023-05-04
 ### Added
 - CASMCMS-8227 - Add platform support to image, recipe, and job objects.

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -210,6 +210,8 @@ data:
               value: "$ssh_jail"
             - name: JOB_ENABLE_DKMS
               value: "$job_enable_dkms"
+            - name: BUILD_ARCH
+              value: "$job_arch"
             resources:
               requests:
                 memory: "$size_gb"

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -8,4 +8,4 @@ image: cray-ims-kiwi-ng-opensuse-x86_64-builder
 
 image: cray-ims-sshd
     major: 1
-    minor: 7
+    minor: 8


### PR DESCRIPTION
## Summary and Scope

For image customization jobs to support arm64, it needs the arch setting pushed to the sshd container so the emulation can be set up.

## Issues and Related PRs
* Resolves [CASMCMS-8365](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8365)

## Testing
### Tested on:

  * `Mug`

### Test description:

Manually updated the customize job template, then successfully ran the arm64 customization jobs. The entire service will be installed on a fresh system shortly for a true verification that everything is set up in the code correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - just adding a new templated env var to a container in a job.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
