### PR TITLE
update default arm64 runtime to kata, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.9.2] - 2023-05-19
+### Changed
+- CASMCMS-8566 - Set default arm64 runtime to kata
+
 ## [3.9.1] - 2023-05-17
 ### Changed
 - CASMCMS-8567 - Support arm64 image customization.

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -90,7 +90,7 @@ customer_access:
 jobs:
   enable_dkms: false
   kata_runtime: "kata-qemu"
-  aarch64_runtime: ""
+  aarch64_runtime: "kata-qemu"
 
 cray-service:
   type: Deployment


### PR DESCRIPTION
## Summary and Scope
Update arm64 build default runtime to kata

## Issues and Related PRs
[CASMCMS-8566](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8566)

## Testing

_List the environments in which these changes were tested._

### Tested on:
Mug

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

