### PR TITLE
hotfix for customize, PVC volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.4] - 2023-06-20
+### Changed
+- CASMCMS-8362 - Utilizing PVC for image-vol volume to support unsquashfs
+
 ## [3.9.3] - 2023-06-15
 ### Changed
 - CASMCMS-8624 - Adding default `kernel_file_name` based on arch type in the Job schema.

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -254,7 +254,7 @@ data:
               - ReadWriteOnce
               resources:
                 requests:
-                  storage: 100Gi
+                  storage: "$pvc_size"
 kind: ConfigMap
 metadata:
   name: cray-configmap-ims-v2-image-customize

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -233,7 +233,7 @@ data:
           - name: ca-pubkey
             configMap:
               name: cray-configmap-ca-public-key
-          - name: ssh-pubkeys
+          - name: ssh-pubkey
             configMap:
               name: cray-ims-$id-configmap
               items:

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -228,14 +228,12 @@ data:
               mountPath: /etc/cray/ca
               readOnly: true
           volumes:
-          - name: image-vol
-            emptyDir: {}
           - name: ims-config-vol
             emptyDir: {}
           - name: ca-pubkey
             configMap:
               name: cray-configmap-ca-public-key
-          - name: ssh-pubkey
+          - name: ssh-pubkeys
             configMap:
               name: cray-ims-$id-configmap
               items:
@@ -244,6 +242,19 @@ data:
           - name: admin-client-auth
             secret:
               secretName: "{{ .Values.keycloak.keycloak_admin_client_auth_secret_name }}"
+          - name: image-vol
+            image-vol:
+              name: image-vol
+              persistentVolumeClaim: 
+                claimName: image-vol-data-claim
+          persistentVolumeClaims:
+            data-claim:
+              name: data-claim
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 100Gi
 kind: ConfigMap
 metadata:
   name: cray-configmap-ims-v2-image-customize

--- a/src/server/v2/resources/jobs.py
+++ b/src/server/v2/resources/jobs.py
@@ -685,6 +685,7 @@ class V2JobCollection(V2BaseJobResource):
             "id": str(new_job.id).lower(),
             "size_gb": str(new_job.build_env_size) + "Gi",
             "limit_gb": str(int(new_job.build_env_size) * 3) + "Gi",
+            "pvc_size": str(int(new_job.build_env_size) * 5) + "Gi",
             "download_url": artifact_info["url"],  # pylint: disable=unsubscriptable-object
             "download_md5sum": artifact_info["md5sum"],  # pylint: disable=unsubscriptable-object
             "public_key": public_key_data,

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -691,6 +691,7 @@ class V3JobCollection(V3BaseJobResource):
             "id": str(new_job.id).lower(),
             "size_gb": str(new_job.build_env_size) + "Gi",
             "limit_gb": str(int(new_job.build_env_size) * 3) + "Gi",
+            "pvc_size": str(int(new_job.build_env_size) * 5) + "Gi",
             "download_url": artifact_info["url"],  # pylint: disable=unsubscriptable-object
             "download_md5sum": artifact_info["md5sum"],  # pylint: disable=unsubscriptable-object
             "public_key": public_key_data,


### PR DESCRIPTION
## Summary and Scope

Needed to change volume configuration from emptyDir to a PVC. Kata containers using emptyDir was giving a "none" filesystem type which caused unsquashfs to fail due to being unable to handle file attributes on a "none" type. 

* Resolves [issue id](issue link) [CASMCMS-8362](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8362)

## Testing

### Test description:
Tested the PVC configuration on Mugenstein.

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable


