### PR TITLE
rollback PVC changes, utilize annotations for virtiofs args xattr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.9.5] - 2023-06-22
+### Changed
 - CASMCMS-8362 - Rollback pvc changes, utilize virtiofs k8s annotation to pass in xattr flag
 
 ## [3.9.4] - 2023-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.5] - 2023-06-22
+- CASMCMS-8362 - Rollback pvc changes, utilize virtiofs k8s annotation to pass in xattr flag
+
 ## [3.9.4] - 2023-06-20
 ### Changed
 - CASMCMS-8362 - Utilizing PVC for image-vol volume to support unsquashfs

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -64,6 +64,8 @@ data:
       backoffLimit: 0
       template:
         metadata:
+          annotations:
+            io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o", "xattr"]'
           labels:
             app: ims-$id-create
         spec:

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
@@ -62,6 +62,8 @@ data:
       backoffLimit: 0
       template:
         metadata:
+          annotations:
+            io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o", "xattr"]'
           labels:
             app: ims-$id-create
         spec:

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -62,6 +62,8 @@ data:
       backoffLimit: 0
       template:
         metadata:
+          annotations:
+            io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o", "xattr"]'
           labels:
             app: ims-$id-customize
         spec:
@@ -228,6 +230,8 @@ data:
               mountPath: /etc/cray/ca
               readOnly: true
           volumes:
+          - name: image-vol
+            emptyDir: {}
           - name: ims-config-vol
             emptyDir: {}
           - name: ca-pubkey
@@ -242,19 +246,6 @@ data:
           - name: admin-client-auth
             secret:
               secretName: "{{ .Values.keycloak.keycloak_admin_client_auth_secret_name }}"
-          - name: image-vol
-            image-vol:
-              name: image-vol
-              persistentVolumeClaim: 
-                claimName: image-vol-data-claim
-          persistentVolumeClaims:
-            data-claim:
-              name: data-claim
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: "$pvc_size"
 kind: ConfigMap
 metadata:
   name: cray-configmap-ims-v2-image-customize


### PR DESCRIPTION
## Summary and Scope

Rolled back PVC changes. Utilize kata annotations to directly configure virtiofs behaviour to enable xattr.

## Issues and Related PRs


* Resolves [CASMCMS-8362](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8362)

## Testing

### Tested on:
Tested on Mug

### Test description:
After enabling annotations in qemu hypervisor file, edited ims creation/customize configmaps to include virtiofs arguments.

## Risks and Mitigations
No risks forseen for this.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

