### PR TITLE
CASMCMS-8362 - rollback annotation from create jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.9.5] - 2023-06-22
 ### Changed
-- CASMCMS-8362 - Rollback pvc changes, utilize virtiofs k8s annotation to pass in xattr flag
+- CASMCMS-8362 - Rollback pvc changes, utilize virtiofs k8s annotation to pass in xattr flag in customize.
 
 ## [3.9.4] - 2023-06-20
 ### Changed

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -64,8 +64,6 @@ data:
       backoffLimit: 0
       template:
         metadata:
-          annotations:
-            io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o", "xattr"]'
           labels:
             app: ims-$id-create
         spec:

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
@@ -62,8 +62,6 @@ data:
       backoffLimit: 0
       template:
         metadata:
-          annotations:
-            io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o", "xattr"]'
           labels:
             app: ims-$id-create
         spec:


### PR DESCRIPTION
## Summary and Scope

Roll back the annotations from the create CM templates so the kata filesystem annotations are only being applied to the customize job.

## Issues and Related PRs
* Resolves [CASMCMS-8362](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8362)

## Testing
### Tested on:
  * `Mug`

### Test description:

Tested the recipe builds with the new settings in the CM.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Medium risk change as we are not sure of the downstream implications, but it shouldn't be any worse off than we were before.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

