### PR TITLE
CASMCMS-8686/8687 - fixes for csm-1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.6] - 2023-06-27
+### Changed
+- CASMCMS-8686 - Fix schema update of jobs records.
+- CASMCMS-8687 - Fix global require_dkms setting.
+
 ## [3.9.5] - 2023-06-22
 ### Changed
 - CASMCMS-8362 - Rollback pvc changes, utilize virtiofs k8s annotation to pass in xattr flag in customize.

--- a/src/server/models/jobs.py
+++ b/src/server/models/jobs.py
@@ -211,8 +211,15 @@ class V2JobRecordSchema(V2JobRecordInputSchema):
     resultant_image_id = fields.UUID(allow_none=True,
                                      description="the unique id of the resultant image record")
     ssh_containers = fields.List(fields.Nested(SshContainerSchema()), allow_none=True)
-    arch = fields.Str(required=False, description="Architecture of the job", default=ARCH_X86_64,
+    arch = fields.Str(description="Architecture of the job", default=ARCH_X86_64,
                           validate=OneOf([ARCH_ARM64,ARCH_X86_64]), load_default=True, dump_default=True)
+
+    # after reading in the data, make sure there is an arch defined - default to x86
+    @post_load(pass_original=False)
+    def fill_arch(self, data, **kwargs):
+        if not "arch" in data or data["arch"] is None:
+            data["arch"] = ARCH_X86_64
+        return data
 
 class V2JobRecordPatchSchema(Schema):
     """

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -696,7 +696,6 @@ class V3JobCollection(V3BaseJobResource):
             "id": str(new_job.id).lower(),
             "size_gb": str(new_job.build_env_size) + "Gi",
             "limit_gb": str(int(new_job.build_env_size) * 3) + "Gi",
-            "pvc_size": str(int(new_job.build_env_size) * 5) + "Gi",
             "download_url": artifact_info["url"],  # pylint: disable=unsubscriptable-object
             "download_md5sum": artifact_info["md5sum"],  # pylint: disable=unsubscriptable-object
             "public_key": public_key_data,

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -654,10 +654,15 @@ class V3JobCollection(V3BaseJobResource):
            # If the architecture is aarch64, then the dkms settings are required
             current_app.logger.info(f" NOTE: aarch64 architecture requires dkms")
             new_job.require_dkms = True
-        elif new_job.job_type == JOB_TYPE_CREATE and artifact_record.require_dkms and userSpecifiedDKMS==None:
-            # Let the setting from the recipe flow through if the user has not specified otherwise
-            current_app.logger.info(f"Overriding require_dkms based on recipe setting")
-            new_job.require_dkms = True
+        elif userSpecifiedDKMS==None:
+            if self.job_enable_dkms:
+                # use the default from the ims-config config map
+                current_app.logger.info(f"Setting require_dkms based on ims-config setting")
+                new_job.require_dkms = True
+            elif new_job.job_type == JOB_TYPE_CREATE and artifact_record.require_dkms:
+                # Let the setting from the recipe flow through if the user has not specified otherwise
+                current_app.logger.info(f"Overriding require_dkms based on recipe setting")
+                new_job.require_dkms = True
 
         # get the public key information
         public_key_data, problem = V3JobCollection.get_public_key_data(log_id, new_job.public_key_id)


### PR DESCRIPTION
## Summary and Scope

There are 2 issues wrapped together in this hotfix:
CASMCMS-8686 - fix jobs record scheme change on helm update.
CASMCMS-8687 - fix global require-dkms setting usage.

Both were found when doing more extensive testing of the csm-1.5 release version of IMS.

## Issues and Related PRs
* Resolves [CASMCMS-8686](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8686)
* Resolves [CASMCMS-8687](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8687)

## Testing
### Tested on:
  * `Mug`

### Test description:

I did a clean install of the csm-1.4 version of IMS on Mug, then did helm upgrade/downgrade testing to insure the schema of the jobs records is correctly updated, and the global require-dkms flag is being used as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

The bigger risk here is not including this fix and possibly getting corrupt job data entries.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

