### PR TITLE
CASMCMS-8707 - push arch env vars to all containers in IMS jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.7] - 2023-07-07
+### Changed
+- CASMCMS-8707 - push arch env vars to all containers in IMS jobs.
+
 ## [3.9.6] - 2023-06-27
 ### Changed
 - CASMCMS-8686 - Fix schema update of jobs records.

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -338,6 +338,8 @@ data:
               value: "$ssh_jail"
             - name: JOB_ENABLE_DKMS
               value: "$job_enable_dkms"
+            - name: BUILD_ARCH
+              value: "$job_arch"
             volumeMounts:
             - name: image-vol
               mountPath: /mnt/image

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -86,6 +86,10 @@ data:
               value: "$id"
             - name: DOWNLOAD_MD5SUM
               value: "$download_md5sum"
+            - name: JOB_ENABLE_DKMS
+              value: "$job_enable_dkms"
+            - name: BUILD_ARCH
+              value: "$job_arch"
             volumeMounts:
             - name: image-vol
               mountPath: /mnt/image
@@ -143,6 +147,8 @@ data:
               value: "$id"
             - name: SSH_JAIL
               value: "$ssh_jail"
+            - name: BUILD_ARCH
+              value: "$job_arch"
             - name: S3_BUCKET
               value: "$s3_bucket"
             - name: S3_ACCESS_KEY


### PR DESCRIPTION
## Summary and Scope

The build arch env variable was not being set in all containers for the IMS jobs kicked off. That meant that it was defaulting to 'x86_64' and in the case of customizing an 'aarch64' image, when complete it was getting incorrectly uploaded and labeled as an 'x86_64' image.

This adds the 'BUILD_ARCH' env variable to the job templates for the containers that was missing that variable. This will get set to the correct value when IMS templates the job and now flows through with the correct value.

## Issues and Related PRs
* Resolves [CASMCMS-8707](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8707)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new IMS helm chart on Mug, then ran jobs to insure the correct values are getting picked up and set.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk change as it is just adding missing env vars to the various containers.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

