### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.3] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
+## [3.7.2] - 2022-12-16
+### Changed
+- CASMTRIAGE-4680 - Use authentication credentials to validate to artifactory
 
 ## [3.7.1] - 2022-09-30
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -24,7 +24,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.2
 python-dateutil==2.8.1
 pytz==2018.4
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.23.0
 requests-oauthlib==1.0.0
 rsa==4.7


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/ims/pull/91 to allow support/3.7 branch to be buildable