### PR TITLE
CASMCMS-8801 - switch jobs to use PVC's for image mounts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
+- CASMCMS-8801 - changed the image volume mounts to ude PVC's instead of ephemeral storage.
 
 ### Dependencies
 Bumped dependency patch versions:

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
   DEFAULT_IMS_IMAGE_SIZE: "15"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
+  DEFAULT_IMS_JOB_MEM_SIZE: "3"
 
   JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN: "{{ .Values.customer_access.shasta_domain }}"
   JOB_CUSTOMER_ACCESS_SUBNET_NAME: "{{ .Values.customer_access.subnet_name }}"

--- a/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ metadata:
   name: ims-service-launch-job
 rules:
   - apiGroups: [""]
-    resources: ["services","configmaps","roles"]
+    resources: ["services","configmaps","roles","persistentvolumeclaims"]
     verbs: ["get", "create", "delete"]
   - apiGroups: ["networking.istio.io"]
     resources: ["destinationrules"]

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -35,6 +35,19 @@ data:
         $public_key
       template_dictionary: |
         $template_dictionary
+  image_pvc_create.yaml.template: |
+    ---
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: cray-ims-$id-job-claim
+      namespace: $namespace
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "$pvc_gb"
   image_service_create.yaml.template: |
     ---
     kind: Service
@@ -90,8 +103,8 @@ data:
             - configMapRef:
                 name: cray-ims-$id-configmap
             volumeMounts:
-            - name: recipe-vol
-              mountPath: /mnt/recipe
+            - name: image-vol
+              mountPath: /mnt/image
             - name: ca-pubkey
               mountPath: /etc/cray/ca
               readOnly: true
@@ -101,13 +114,13 @@ data:
             - name: template-dictionary
               mountPath: /etc/cray
               readOnly: true
-            command: [ "sh", "-ce", "/scripts/fetch-recipe.sh /mnt/recipe \"$download_url\"" ]
+            command: [ "sh", "-ce", "/scripts/fetch-recipe.sh /mnt/image/recipe \"$download_url\"" ]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           # Step 2: Wait for Repos
           - image: {{ .Values.cray_ims_utils.image.repository }}:{{ .Values.cray_ims_utils.image.tag }}
@@ -117,15 +130,14 @@ data:
             - name: CA_CERT
               value: /etc/cray/ca/certificate_authority.crt
             - name: RECIPE_ROOT_PARENT
-              value: /mnt/recipe
+              value: /mnt/image/recipe
             - name: IMS_JOB_ID
               value: "$id"
             - name: OAUTH_CONFIG_DIR
               value: '/etc/admin-client-auth'
             volumeMounts:
-            - name: recipe-vol
-              mountPath: /mnt/recipe
-              readOnly: true
+            - name: image-vol
+              mountPath: /mnt/image
             - name: ca-pubkey
               mountPath: /etc/cray/ca
               readOnly: true
@@ -135,10 +147,10 @@ data:
             command: [ "sh", "-ce", "/scripts/wait_for_kiwi_repos.py" ]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           # Step 3: Build a RPM containing the Cray Root CA certificate
           - image: {{ .Values.cray_ims_utils.image.repository }}:{{ .Values.cray_ims_utils.image.tag }}
@@ -170,10 +182,10 @@ data:
             command: [ "/scripts/build_ca_rpm.py" ]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           # Step 4: Build the image
           - image: {{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}
@@ -181,10 +193,10 @@ data:
             name: build-image
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "48"
             securityContext:
               privileged: true
@@ -200,7 +212,7 @@ data:
             - name: ENABLE_DEBUG
               value: '$enable_debug'
             - name: RECIPE_ROOT_PARENT
-              value: /mnt/recipe
+              value: /mnt/image/recipe
             - name: IMAGE_ROOT_PARENT
               value: /mnt/image
             - name: IMS_JOB_ID
@@ -212,9 +224,6 @@ data:
             - name: IMS_ARM_BUILDER
               value: "{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}"
             volumeMounts:
-            - name: recipe-vol
-              mountPath: /mnt/recipe
-              readOnly: true
             - name: image-vol
               mountPath: /mnt/image
             - name: ca-rpm-vol
@@ -233,10 +242,10 @@ data:
             command: ["sh", "-ce", "/scripts/buildenv-sidecar.sh /mnt/image"]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "48"
             envFrom:
             - configMapRef:
@@ -350,16 +359,15 @@ data:
               readOnly: true
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           volumes:
           - name: image-vol
-            emptyDir: {}
-          - name: recipe-vol
-            emptyDir: {}
+            persistentVolumeClaim:
+              claimName: cray-ims-$id-job-claim
           - name: specfile-vol
             configMap:
               name: ims-ca-rpm-specfile

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-packer-job-template.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -51,6 +51,19 @@ data:
       - port: 22
         protocol: TCP
         targetPort: 22
+  image_pvc_create.yaml.template: |
+    ---
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: cray-ims-$id-job-claim
+      namespace: $namespace
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "$pvc_gb"
   image_job_create.yaml.template: |
     ---
     apiVersion: batch/v1
@@ -88,21 +101,21 @@ data:
             - configMapRef:
                 name: cray-ims-$id-configmap
             volumeMounts:
-            - name: recipe-vol
-              mountPath: /mnt/recipe
+            - name: image-vol
+              mountPath: /mnt/image
             - name: ca-pubkey
               mountPath: /etc/cray/ca
               readOnly: true
             - name: admin-client-auth
               mountPath: '/etc/admin-client-auth'
               readOnly: true
-            command: [ "sh", "-ce", "/scripts/fetch-recipe.sh /mnt/recipe \"$download_url\"" ]
+            command: [ "sh", "-ce", "/scripts/fetch-recipe.sh /mnt/image/recipe \"$download_url\"" ]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           # Step 4: Build the image
           - image: {{ .Values.cray_ims_packer_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_packer_opensuse_x86_64_builder.image.tag }}
@@ -110,10 +123,10 @@ data:
             name: build-image
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "48"
             securityContext:
               privileged: true
@@ -127,15 +140,12 @@ data:
             - name: ENABLE_DEBUG
               value: '$enable_debug'
             - name: RECIPE_ROOT_PARENT
-              value: /mnt/recipe
+              value: /mnt/image/recipe
             - name: IMAGE_ROOT_PARENT
               value: /mnt/image
             - name: IMS_JOB_ID
               value: "$id"
             volumeMounts:
-            - name: recipe-vol
-              mountPath: /mnt/recipe
-              readOnly: true
             - name: ca-rpm-vol
               mountPath: /mnt/ca-rpm
             - name: image-vol
@@ -153,10 +163,10 @@ data:
             command: ["sh", "-ce", "/scripts/buildenv-sidecar.sh /mnt/image"]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "48"
             envFrom:
             - configMapRef:
@@ -256,16 +266,15 @@ data:
               readOnly: true
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           volumes:
           - name: image-vol
-            emptyDir: {}
-          - name: recipe-vol
-            emptyDir: {}
+            persistentVolumeClaim:
+              claimName: cray-ims-$id-job-claim
           - name: specfile-vol
             configMap:
               name: ims-ca-rpm-specfile

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -51,6 +51,19 @@ data:
       - port: 22
         protocol: TCP
         targetPort: 22
+  image_pvc_customize.yaml.template: |
+    ---
+    kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: cray-ims-$id-job-claim
+      namespace: $namespace
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "$pvc_gb"
   image_job_customize.yaml.template: |
     ---
     apiVersion: batch/v1
@@ -102,10 +115,10 @@ data:
             command: [ "sh", "-ce", "/scripts/prep-env.sh /mnt/image \"$download_url\"" ]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
           # User customization of image root
           containers:
@@ -115,10 +128,10 @@ data:
             command: ["sh", "-ce", "/scripts/buildenv-sidecar.sh /mnt/image"]
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "48"
             env:
             - name: API_GATEWAY_HOSTNAME
@@ -222,10 +235,10 @@ data:
               value: "$job_arch"
             resources:
               requests:
-                memory: "$size_gb"
+                memory: "$job_mem_size"
                 cpu: "500m"
               limits:
-                memory: "$limit_gb"
+                memory: "$job_mem_limit"
                 cpu: "8"
             volumeMounts:
             - name: image-vol
@@ -236,6 +249,9 @@ data:
               mountPath: /etc/cray/ca
               readOnly: true
           volumes:
+          - name: image-vol
+            persistentVolumeClaim:
+              claimName: cray-ims-$id-job-claim
           - name: ims-config-vol
             emptyDir: {}
           - name: ca-pubkey
@@ -250,19 +266,6 @@ data:
           - name: admin-client-auth
             secret:
               secretName: "{{ .Values.keycloak.keycloak_admin_client_auth_secret_name }}"
-          - name: image-vol
-            image-vol:
-              name: image-vol
-              persistentVolumeClaim: 
-                claimName: image-vol-data-claim
-          persistentVolumeClaims:
-            data-claim:
-              name: data-claim
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: "$pvc_size"
 kind: ConfigMap
 metadata:
   name: cray-configmap-ims-v2-image-customize

--- a/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
+++ b/kubernetes/cray-ims/templates/post_upgrade_hook.yaml
@@ -79,6 +79,11 @@ spec:
               cp /var/ims/data/v2_jobs.json /var/ims/data/v2.1_jobs.json
             fi
 
+            if [[ -f /var/ims/data/v2.1_jobs.json ]] && [[ ! -f /var/ims/data/v2.2_jobs.json ]]
+            then
+              cp /var/ims/data/v2.1_jobs.json /var/ims/data/v2.2_jobs.json
+            fi
+
             chown -Rv 65534:65534 /var/ims/data
         volumeMounts:
           - mountPath: /var/ims/data

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -74,7 +74,7 @@ def load_datastore(_app):
         V3DeletedImageRecordSchema(), 'id')
 
     _app.data['jobs'] = DataStoreHACK(
-        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.1_jobs.json'),
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.2_jobs.json'),
         V2JobRecordSchema(), 'id')
 
 

--- a/src/server/v2/resources/jobs.py
+++ b/src/server/v2/resources/jobs.py
@@ -168,13 +168,13 @@ class V2BaseJobResource(Resource):
 
     def create_kubernetes_resources(self, log_id, new_job, template_params, recipe_type):
         """
-        Create kubernetes resources (configmap, service, job and destination_rule) for the current job
+        Create kubernetes resources (configmap, service, job, pvc, and destination_rule) for the current job
         """
 
         k8s_client = client.ApiClient()
         new_job.kubernetes_namespace = self.default_ims_job_namespace
         root_template_path = os.environ.get("IMS_JOB_TEMPLATE_PATH", "/mnt/ims/v2/job_templates")
-        for resource in ("configmap", "service", "job"):
+        for resource in ("configmap", "service", "job", "pvc"):
             resource_field = "kubernetes_%s" % resource
             fd, output_file_name = tempfile.mkstemp(suffix=".yaml")
             try:
@@ -259,11 +259,18 @@ class V2BaseJobResource(Resource):
         if delete_job:
             resources['job'] = k8s_batchv1api.delete_namespaced_job
             resources['configmap'] = k8s_v1api.delete_namespaced_config_map
+            resources['pvc'] = k8s_v1api.delete_namespaced_persistent_volume_claim
 
         # Delete the underlying kubernetes service, job and configmap resources
         for resource, delete_fn in resources.items():
+            # PVC's were added to the job in v2.2 of the schema - they may not exist
+            # for jobs created before an upgrade.
             name = getattr(job, "kubernetes_%s" % resource)
-            current_app.logger.info("%s Deleting k8s %s %s.", log_id, resource, name)
+            if name != None:
+                current_app.logger.info(f"{log_id} Deleting k8s {resource} {name}.")
+            else:
+                current_app.logger.info(f"{log_id} k8s resource does not exist for job {resource}.")
+                continue
 
             try:
                 delete_fn(body=k8s_delete_options, namespace=namespace, name=name)
@@ -690,6 +697,9 @@ class V2JobCollection(V2BaseJobResource):
             "id": str(new_job.id).lower(),
             "size_gb": str(new_job.build_env_size) + "Gi",
             "limit_gb": str(int(new_job.build_env_size) * 3) + "Gi",
+            "pvc_gb": str(int(new_job.build_env_size) * 5) + "Gi",
+            "job_mem_size": str(new_job.job_mem_size) + "Gi",
+            "job_mem_limit": str(int(new_job.job_mem_size) * 3) + "Gi",
             "download_url": artifact_info["url"],  # pylint: disable=unsubscriptable-object
             "download_md5sum": artifact_info["md5sum"],  # pylint: disable=unsubscriptable-object
             "public_key": public_key_data,

--- a/tests/v2/test_v2_jobs.py
+++ b/tests/v2/test_v2_jobs.py
@@ -422,7 +422,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -486,7 +487,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -534,7 +536,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     def test_post_create_with_ssh_container(self, utils_mock, config_mock, client_mock):
@@ -630,7 +633,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     @responses.activate
@@ -733,7 +737,8 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
     
 

--- a/tests/v3/test_v3_jobs.py
+++ b/tests/v3/test_v3_jobs.py
@@ -428,7 +428,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name','arch', 'require_dkms'],
+                               'kernel_parameters_file_name','arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -492,7 +493,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name','arch', 'require_dkms'],
+                               'kernel_parameters_file_name','arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -540,7 +542,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     def test_post_create_with_ssh_container(self, utils_mock, config_mock, client_mock):
@@ -637,7 +640,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
     @responses.activate
@@ -740,7 +744,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'public_key_id', 'kubernetes_job', 'kubernetes_service', 'kubernetes_configmap',
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
-                               'kernel_parameters_file_name', 'arch', 'require_dkms'],
+                               'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
+                               'job_mem_size'],
                               'returned keys not the same')
 
 


### PR DESCRIPTION
## Summary and Scope

There is a limited amount of ephemeral storage on the k8s cluster. We were seeing cases where IMS jobs were failing due to insufficient resources. In order to resolve this, I switched the primary image and recipe mounts in the IMS jobs to use PVC's for volume mounts instead of the ephemeral storage they were using.

## Issues and Related PRs
* Resolves [CASMCMS-8801](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8801)
* Change will also be needed in ims-utils and ims-kiwi-builder repos.

## Testing
### Tested on:
  * `Mug`

### Test description:

I did a helm install/upgrade/downgrade. I ran all the dkms and non/dkms recipe build and customization permutations. They all performed as expected. There is a change to the job data record (to keep track of the PVC created for the job) and I did upgrade/downgrade testing.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a rather large fundamental change, but there is no other way to ease the pressure on the ephemeral storage resources.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

