### PR TITLE
CASMCMS-8828 - increase default mem size for jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.1] - 2023-10-05
+### Changed
+- CASMCMS-8828 - increase the default mem requests and limits on jobs.
+
 ## [3.10.0] - 2023-09-15
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
   DEFAULT_IMS_IMAGE_SIZE: "15"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
-  DEFAULT_IMS_JOB_MEM_SIZE: "3"
+  DEFAULT_IMS_JOB_MEM_SIZE: "5"
 
   JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN: "{{ .Values.customer_access.shasta_domain }}"
   JOB_CUSTOMER_ACCESS_SUBNET_NAME: "{{ .Values.customer_access.subnet_name }}"


### PR DESCRIPTION
## Summary and Scope

When PVC's were introduced for image storage we decreased the memory requests and limit sizes to make scheduling jobs easier. With some larger jobs, the new default was not sufficient, so this bumps it back up a bit.

## Issues and Related PRs
* Resolves [CASMCMS-8828](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8828)

## Testing
### Tested on:
  * `Slice`

### Test description:

Manual change of the setting resulted in successful job completion.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just increasing resource allocations.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

