### PR TITLE
CASMCMS-8795 - add remote build node objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ - CASMCMS-8795 - add remote-build-nodes API.
 
 ## [3.10.0] - 2023-09-15
 ### Changed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -66,6 +66,17 @@ info:
         artifact repository. Recipes themselves define how an image is to be created, including the
         RPMs that will be installed, the RPM repositories to use, etc.
 
+      ### /remote-build-nodes
+
+        Manage the set of nodes set up for running remote jobs. These are jobs that are
+        run on nodes outside of the set of Kubernetes worker nodes. They can be used to
+        offload work from the worker nodes, or match the archetecture of the images
+        being created or customized.
+
+        The remote node must be fully configured and booted into the 'remote-node-image'
+        by the site-admin prior to registration in IMS. It will be tested prior to job
+        launch and if it is not accessible or correctly configured it will not be used.
+
     ## Workflows
 
       There are two main workflows using the IMS - image creation and image customization.
@@ -521,6 +532,99 @@ paths:
       responses:
         '204':
           description: Public Key record deleted successfully
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v3/remote-build-nodes:
+    get:
+      summary: List remote build nodes
+      operationId: get_all_v3_remote_build_nodes
+      tags:
+        - remote build node
+        - v3
+      description: Retrieve a list of remote build nodes that are registered with IMS.
+      responses:
+        '200':
+          description: A collection of remote build nodes
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/RemoteBuildNodeRecord'
+                type: array
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Create a new remote built node record
+      operationId: post_v3_remote_build_node
+      tags:
+        - remote build node
+        - v3
+      description: Create a new remote build node record. Updated by administrator to allow them to run jobs on a remote build node.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoteBuildNodeRecord'
+        description: Remote build node record to create
+        required: true
+      responses:
+        '201':
+          description: New RemoteBuildNode
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteBuildNodeRecord'
+        '400':
+          $ref: '#/components/responses/NoInputProvided'
+        '422':
+          $ref: '#/components/responses/InvalidInputData'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Delete all RemoteBuildNodeRecords
+      operationId: delete_all_v3_remote_build_nodes
+      tags:
+        - remote build node
+        - v3
+      description: Delete all remote build node records.
+      responses:
+        '204':
+          description: Remote build node records deleted successfully
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/v3/remote-build-nodes/{remote_build_node_xname}':
+    parameters:
+      - $ref: '#/components/parameters/remote_build_node_xname'
+    get:
+      summary: Retrieve a remote build node by remote_build_node_xname
+      operationId: get_v3_remote_build_node
+      tags:
+        - remote build node
+        - v3
+      description: Retrieve a remote build node by remote_build_node_xname
+      responses:
+        '200':
+          description: A remote build node record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteBuildNodeRecord'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Delete remote build node by remote_build_node_xname
+      operationId: delete_v3_remote_build_node
+      tags:
+        - remote build node
+        - v3
+      description: Delete a RemoteBuildNodeRecord by Xname.
+      responses:
+        '204':
+          description: Remote build node record deleted successfully
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1640,6 +1744,10 @@ paths:
     $ref: "#/paths/~1v2~1public-keys"
   /public-keys/{public_key_id}:
     $ref: "#/paths/~1v2~1public-keys~1{public_key_id}"
+  /remote-build-nodes:
+    $ref: "#/paths/~1v3~1remote-build-nodes"
+  /remote-build-nodes/{remote_build_node_xname}:
+    $ref: "#/paths/~1v3~1remote-build-nodes~1{remote_build_node_xname}"
   /jobs:
     $ref: "#/paths/~1v2~1jobs"
   /jobs/{job_id}:
@@ -1742,6 +1850,14 @@ components:
         type: string
         format: uuid
       example: bc6ec895-6ff5-4481-bd98-88ed4cd233e9
+    remote_build_node_xname:
+      description: The unique xname of a remote build node
+      in: path
+      name: remote_build_node_xname
+      required: true
+      schema:
+        type: string
+      example: x3000c1s10b1n0
     job_id:
       description: The unique ID of a job
       in: path
@@ -1943,6 +2059,17 @@ components:
             ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA ...
             fa6hG9i2SzfY8L6vAVvSE7A2ILAsVruw1Zeiec2IWt
 
+          type: string
+          minLength: 1
+    RemoteBuildNodeRecord:
+      description: A Remote Build Node Record
+      type: object
+      required:
+        - xname
+      properties:
+        xname:
+          description: Xname of the remote build node
+          example: x3000c1s10b1n0
           type: string
           minLength: 1
     ArtifactLinkRecord:

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,6 +6,7 @@ certifi==2019.11.28
 chardet==3.0.4
 click==6.7
 docutils==0.14
+fabric==3.2.2
 Flask==1.1.4
 flask-marshmallow==0.9.0
 Flask-RESTful==0.3.10

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -211,6 +211,8 @@ data:
               value: '/etc/admin-client-auth'
             - name: ENABLE_DEBUG
               value: '$enable_debug'
+            - name: REMOTE_BUILD_NODE
+              value: '$remote_build_node'
             - name: RECIPE_ROOT_PARENT
               value: /mnt/image/recipe
             - name: IMAGE_ROOT_PARENT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -c constraints.txt
 
 # Application requirements for cms-ims
+fabric
 flask
 flask-restful
 flask_marshmallow

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -30,7 +30,7 @@ import collections
 import os
 import os.path
 
-class DataStoreHACK(collections.MutableMapping):
+class DataStoreHACK(collections.abc.MutableMapping):
     """ A dictionary that reads/writes to a file """
 
     def __init__(self, store_file, schema_obj, key_field, *args, **kwargs):

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -47,6 +47,7 @@ from src.server.v3.models.recipes import V3DeletedRecipeRecordSchema
 from src.server.models.images import V2ImageRecordSchema
 from src.server.v3.models.images import V3DeletedImageRecordSchema
 from src.server.models.jobs import V2JobRecordSchema
+from src.server.models.remote_build_nodes import V3RemoteBuildNodeRecordSchema
 
 
 def load_datastore(_app):
@@ -76,6 +77,10 @@ def load_datastore(_app):
     _app.data['jobs'] = DataStoreHACK(
         os.path.join(_app.config['HACK_DATA_STORE'], 'v2.2_jobs.json'),
         V2JobRecordSchema(), 'id')
+
+    _app.data['remote_build_nodes'] = DataStoreHACK(
+        os.path.join(_app.config['HACK_DATA_STORE'], 'v2.0_remote_build_nodes.json'),
+        V3RemoteBuildNodeRecordSchema(), 'xname')
 
 
 def load_v2_api(_app):
@@ -142,7 +147,11 @@ def create_app():
     _app.logger.setLevel(_app.config['LOG_LEVEL'])
     _app.logger.info('Image management service configured in {} mode'.format(os.getenv('FLASK_ENV', 'production')))
 
+    # dictionary to all the data store objects
     _app.data = {}
+
+    #dictionary to all the remote build node status objects
+    _app.remoteNodes = {}
 
     # log the gunicorn worker timeout on startup
     _app.logger.info(f"Gunicorn worker timeout: {os.getenv('GUNICORN_WORKER_TIMEOUT', '-1')}")

--- a/src/server/models/jobs.py
+++ b/src/server/models/jobs.py
@@ -84,7 +84,7 @@ class V2JobRecord:
                  build_env_size=None, image_root_archive_name=None, kernel_file_name=None,
                  initrd_file_name=None, resultant_image_id=None, ssh_containers=None,
                  kubernetes_namespace=None, kernel_parameters_file_name=None, require_dkms=False,
-                 arch=None, job_mem_size=None, kubernetes_pvc=None):
+                 arch=None, job_mem_size=None, kubernetes_pvc=None, remote_build_node=""):
         # Supplied
         # v2.0
         self.job_type = job_type
@@ -118,6 +118,9 @@ class V2JobRecord:
         # v2.2
         self.kubernetes_pvc = kubernetes_pvc
         self.job_mem_size = job_mem_size or DEFAULT_JOB_MEM_SIZE
+
+        # v2.3
+        self.remote_build_node = remote_build_node or ""
 
     def __repr__(self):
         return '<v2JobRecord(id={self.id!r})>'.format(self=self)
@@ -231,6 +234,10 @@ class V2JobRecordSchema(V2JobRecordInputSchema):
     # v2.2
     kubernetes_pvc = fields.Str(allow_none=True,
                                       description="PVC name for the underlying Kubernetes image pvc")
+
+    # v2.3
+    remote_build_node = fields.Str(allow_none=False, default="",
+                                        description="XName of remote job if running on a remote node")
 
     # after reading in the data, make sure there is an arch defined - default to x86
     @post_load(pass_original=False)

--- a/src/server/models/remote_build_nodes.py
+++ b/src/server/models/remote_build_nodes.py
@@ -1,0 +1,166 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Remote Build Nodes
+"""
+
+import socket
+from flask import current_app as app
+
+from marshmallow import Schema, fields, post_load, RAISE
+from marshmallow.validate import Length, OneOf
+
+from fabric import Connection
+from paramiko.ssh_exception import (SSHException, NoValidConnectionsError, 
+                                    AuthenticationException, BadHostKeyException)
+from invoke.exceptions import UnexpectedExit, Failure
+
+from src.server.helper import ARCH_ARM64, ARCH_X86_64
+
+class V3RemoteBuildNodeRecord:
+    """ The RemoteBuildNodeRecord object """
+
+    # pylint: disable=W0622
+    def __init__(self, xname):
+        # Supplied
+        self.xname = xname
+
+    def __repr__(self):
+        return '<V3RemoteBuildNodeRecord(xname={self.xname!r})>'.format(self=self)
+
+    def getStatus(self) -> (str, int): #(arch, current jobs)
+        """
+        Utility function to verify that a node is set up and available for remote
+        builds. If the node can not be contacted or is not set up for running IMS
+        jobs, this will return (None,None)
+        
+        Returns:
+            Archetecture of the node if it can be determined
+            Number of jobs currently running on the node
+
+        """
+
+        # start with status Invalid
+        arch = None
+        numJobs = None
+
+        # connect to the remote node
+        # TODO: need to figure out where the key value is stored and how to use...
+        connect_kwargs = {"key_filename": "/tmp/ssh/id_rsa"}
+        c = Connection(self.xname, user="root", connect_kwargs=connect_kwargs)
+
+        # validate the connection
+        try: 
+            c.open()
+        except (BadHostKeyException, AuthenticationException, NoValidConnectionsError,
+                SSHException, socket.error) as error:
+            app.logger.error(f"Unable to connect to node: {self.xname}, Error: {error}")
+            return arch, numJobs
+
+        # make sure the above connection gets closed on exit
+        try:
+            # get arch of the system
+            try:
+                # query node for arch
+                result = c.run("uname -i", hide=True)
+
+                # check result
+                if result.exited != 0:
+                    app.logger.error(f"Unable to determine archecture of node: {self.xname}, Error: {result.stdout} {result.stderr}")
+                    return arch, numJobs
+
+                # see if we can pull out a known arch type
+                if "aarch64" in result.stdout:
+                    arch = ARCH_ARM64
+                elif "x86" in result.stdout:
+                    arch = ARCH_X86_64
+                else:
+                    app.logger.error(f"Unable to determine archecture of node: {self.xname}, Error: {result.stdout}")
+                    return arch, numJobs
+            except (UnexpectedExit, Failure) as error:
+                app.logger.error(f"Unable to determine archecture of node: {self.xname}, Error: {error}")
+                return arch, numJobs
+
+            # insure it has podman installed
+            try:
+                # query node for arch
+                result = c.run("which podman", hide=True)
+
+                # check result
+                if result.exited != 0:
+                    app.logger.error(f"Unable to determine if podman is installed on node: {self.xname}, Error: {result.stdout} {result.stderr}")
+                    return None,None
+
+                # see if we can pull out a known arch type
+                if "/usr/bin/podman" not in result.stdout:
+                    app.logger.error(f"Podman not installed on node: {self.xname}, Error: {result.stdout}")
+                    return
+            except (UnexpectedExit, Failure) as error:
+                app.logger.error(f"Unable determine if tools are installed on node: {self.xname}, Error: {error}")
+                return None,None
+
+            # Every running IMS job will create a working directory '/tmp/ims_(IMS_JOB_ID)'.
+            # Count the number of these directories to find the number of running jobs on
+            # the node - they are cleaned up when the job is complete on the node.
+            # execute: "ls -d1 /tmp/* | grep /tmp/ims_ | wc -l"
+            try:
+                result = c.run("ls -d1 /tmp/* | grep /tmp/ims_ | wc -l", hide=True)
+                if result.exited != 0:
+                    # let this go through and schedule a job on the node
+                    app.logger.error(f"Unable to determine number of jobs on node: {self.xname}, Error: {result.stdout} {result.stderr}")
+                    numJobs = 0
+                else:
+                    numJobs = int(result.stdout)
+            except (UnexpectedExit, Failure) as error:
+                # Just log this, but allow the job to run
+                app.logger.error(f"Unable determine number of running jobs on node: {self.xname}, Error: {error}")
+                numJobs = 0
+        finally:
+            # close tha active connection
+            c.close()
+
+        return arch, numJobs
+
+
+class V3RemoteBuildNodeRecordInputSchema(Schema):
+    """ A schema specifically for defining and validating user input """
+    xname = fields.Str(required=True, description="The XName of the remote build node",
+                      validate=Length(min=1, error="name field must not be blank"))
+
+    @post_load
+    def make_remote_build_node(self, data):
+        """ Marshall an object out of the individual data components """
+        return V3RemoteBuildNodeRecord(**data)
+
+    class Meta:  # pylint: disable=missing-docstring
+        model = V3RemoteBuildNodeRecord
+        unknown = RAISE  # do not allow unknown fields in the schema
+
+
+class V3RemoteBuildNodeRecordSchema(V3RemoteBuildNodeRecordInputSchema):
+    """
+    Schema for a fully-formed RemoteBuildNode object such as an object being
+    read in from a database. Builds upon the basic input fields in
+    RemoteBuildNodeInputSchema.
+    """

--- a/src/server/v3/__init__.py
+++ b/src/server/v3/__init__.py
@@ -40,7 +40,8 @@ from src.server.v3.resources.public_keys import \
 from src.server.v3.resources.recipes import \
     V3RecipeResource, V3RecipeCollection, \
     V3DeletedRecipeResource, V3DeletedRecipeCollection
-
+from src.server.v3.resources.remote_build_nodes import V3RemoteBuildNodeResource, \
+    V3RemoteBuildNodeCollection
 app_errors = {
     # Custom 405 error format to conform to RFC 7807
     'MethodNotAllowed': json.loads(
@@ -53,6 +54,13 @@ apiv3 = Api(apiv3_blueprint, catch_all_404s=False, errors=app_errors)
 
 # Routes
 for uri_prefix, endpoint_prefix in [('/v3', 'v3')]:
+    apiv3.add_resource(V3RemoteBuildNodeResource,
+                       '/'.join([uri_prefix, 'remote-build-nodes/<remote_build_node_xname>']),
+                       endpoint='_'.join([endpoint_prefix, 'remote_build_node_resource']))
+    apiv3.add_resource(V3RemoteBuildNodeCollection,
+                       '/'.join([uri_prefix, 'remote-build-nodes']),
+                       endpoint='_'.join([endpoint_prefix, 'remote_build_nodes_collection']))
+
     apiv3.add_resource(V3PublicKeyResource,
                        '/'.join([uri_prefix, 'public-keys/<public_key_id>']),
                        endpoint='_'.join([endpoint_prefix, 'public_key_resource']))

--- a/src/server/v3/resources/remote_build_nodes.py
+++ b/src/server/v3/resources/remote_build_nodes.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 """
-Public Keys API
+Remote Build Nodes API
 """
 
 import http.client
@@ -32,35 +32,35 @@ from flask_restful import Resource
 from src.server.errors import problemify, generate_missing_input_response, generate_data_validation_failure, \
     generate_resource_not_found_response
 from src.server.helper import get_log_id
-from src.server.models.publickeys import V2PublicKeyRecordInputSchema, V2PublicKeyRecordSchema
+from src.server.models.remote_build_nodes import V3RemoteBuildNodeRecordInputSchema, V3RemoteBuildNodeRecordSchema, V3RemoteBuildNodeRecord
+from src.server.v3.models import PATCH_OPERATION_UNDELETE
 
-public_key_user_input_schema = V2PublicKeyRecordInputSchema()
-public_key_schema = V2PublicKeyRecordSchema()
+remote_build_node_user_input_schema = V3RemoteBuildNodeRecordInputSchema()
+remote_build_node_schema = V3RemoteBuildNodeRecordSchema()
 
-
-class V2PublicKeyCollection(Resource):
+class V3RemoteBuildNodeCollection(Resource):
     """
-    Class representing the operations that can be taken on a collection of public keys
+    Class representing the operations that can be taken on a collection of remote builds nodes
     """
 
     def get(self):
-        """ retrieve a list/collection of public keys """
+        """ retrieve a list/collection of remote build nodes """
         log_id = get_log_id()
-        current_app.logger.info("%s ++ public_keys.v2.GET", log_id)
-        return_json = public_key_schema.dump(iter(current_app.data["public_keys"].values()), many=True)
+        current_app.logger.info("%s ++ remote_build_nodes.v3.GET", log_id)
+        return_json = remote_build_node_schema.dump(iter(current_app.data['remote_build_nodes'].values()), many=True)
         current_app.logger.info("%s Returning json response: %s", log_id, return_json)
         return jsonify(return_json)
 
     def post(self):
-        """ Add a new public key to the IMS Service.
+        """ Add a new remote build node to the IMS Service.
 
-        A new public key is created from values that passed in via the request body. If the public key already
-        exists, then a 400 is returned. If the public key is created successfully then a 201 is returned.
+        A new remote build node is created from values that passed in via the request body. If the remote build
+        node already exists, then a 400 is returned. If the remote build node is created successfully then a 201
+        is returned.
 
         """
-
         log_id = get_log_id()
-        current_app.logger.info("%s ++ public_keys.v2.POST", log_id)
+        current_app.logger.info("%s ++ remote_build_nodes.v3.POST", log_id)
 
         json_data = request.get_json()
         if not json_data:
@@ -70,33 +70,33 @@ class V2PublicKeyCollection(Resource):
         current_app.logger.info("%s json_data = %s", log_id, json_data)
 
         # Validate input
-        errors = public_key_user_input_schema.validate(json_data)
+        errors = remote_build_node_user_input_schema.validate(json_data)
         if errors:
             current_app.logger.info("%s There was a problem validating the post data: %s", log_id, errors)
             return generate_data_validation_failure(errors)
 
-        # Create a public key record if the user input data was valid
-        new_public_key = public_key_schema.load(json_data)
+        # Create a remote build node record if the user input data was valid
+        new_remote_build_node = remote_build_node_schema.load(json_data)
 
         # Save to datastore
-        current_app.data['public_keys'][str(new_public_key.id)] = new_public_key
+        current_app.data['remote_build_nodes'][str(new_remote_build_node.xname)] = new_remote_build_node
 
-        return_json = public_key_schema.dump(new_public_key)
+        return_json = remote_build_node_schema.dump(new_remote_build_node)
         current_app.logger.info("%s Returning json response: %s", log_id, return_json)
         return return_json, 201
 
     def delete(self):
-        """ Delete all public keys. """
+        """ Delete all remote build nodes. """
         log_id = get_log_id()
-        current_app.logger.info("%s ++ public_keys.v2.DELETE", log_id)
+        current_app.logger.info("%s ++ remote_build_nodes.v3.DELETE", log_id)
 
         try:
-            del current_app.data['public_keys']
-            current_app.data['public_keys'] = {}
+            del current_app.data['remote_build_nodes']
+            current_app.data['remote_build_nodes'] = {}
         except KeyError as key_error:
             current_app.logger.info("%s Key not found: %s", log_id, key_error)
             return None, problemify(status=http.client.INTERNAL_SERVER_ERROR,
-                                    detail='An error was encountered deleting public keys. Review the errors, '
+                                    detail='An error was encountered deleting remote build nodes. Review the errors, '
                                            'take any corrective action and then re-run the request with valid '
                                            'information.')
 
@@ -104,31 +104,31 @@ class V2PublicKeyCollection(Resource):
         return None, 204
 
 
-class V2PublicKeyResource(Resource):
-    """ Endpoint for the public-keys/{public_key_id} resource. """
+class V3RemoteBuildNodeResource(Resource):
+    """ Endpoint for the remote-build-nodes/{remote_build_node_xname} resource. """
 
-    def get(self, public_key_id):
-        """ Retrieve a public key. """
+    def get(self, remote_build_node_xname):
+        """ Retrieve a remote build node. """
         log_id = get_log_id()
-        current_app.logger.info("%s ++ public_keys.v2.GET %s", log_id, public_key_id)
+        current_app.logger.info("%s ++ remote_build_nodes.v3.GET %s", log_id, remote_build_node_xname)
 
-        if public_key_id not in current_app.data["public_keys"]:
-            current_app.logger.info("%s no IMS public_key matches public_key_id=%s", log_id, public_key_id)
+        if remote_build_node_xname not in current_app.data['remote_build_nodes']:
+            current_app.logger.info("%s no IMS remote bild node matches xname=%s", log_id, remote_build_node_xname)
             return generate_resource_not_found_response()
 
-        return_json = public_key_schema.dump(current_app.data['public_keys'][public_key_id])
+        return_json = remote_build_node_schema.dump(current_app.data['remote_build_nodes'][remote_build_node_xname])
         current_app.logger.info("%s Returning json response: %s", log_id, return_json)
         return jsonify(return_json)
 
-    def delete(self, public_key_id):
-        """ Delete a public key. """
+    def delete(self, remote_build_node_xname):
+        """ Delete a remote build node. """
         log_id = get_log_id()
-        current_app.logger.info("%s ++ public_keys.v2.DELETE %s", log_id, public_key_id)
+        current_app.logger.info("%s ++ remote_build_nodes.v3.DELETE %s", log_id, remote_build_node_xname)
 
         try:
-            del current_app.data['public_keys'][public_key_id]
+            del current_app.data['remote_build_nodes'][remote_build_node_xname]
         except KeyError:
-            current_app.logger.info("%s no IMS public_key matches public_key_id=%s", log_id, public_key_id)
+            current_app.logger.info("%s no remote build node record matches xname=%s", log_id, remote_build_node_xname)
             return generate_resource_not_found_response()
 
         current_app.logger.info("%s return 204", log_id)

--- a/tests/v2/test_v2_jobs.py
+++ b/tests/v2/test_v2_jobs.py
@@ -423,7 +423,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -488,7 +488,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
     @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
@@ -537,7 +537,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
     def test_post_create_with_ssh_container(self, utils_mock, config_mock, client_mock):
@@ -634,7 +634,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
     @responses.activate
@@ -738,7 +738,7 @@ class TestV2JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
     
 

--- a/tests/v3/ims_fixtures.py
+++ b/tests/v3/ims_fixtures.py
@@ -36,7 +36,7 @@ from src.server.v3.models.public_keys import V3DeletedPublicKeyRecordSchema
 from src.server.models.recipes import V2RecipeRecordSchema
 from src.server.v3.models.recipes import V3DeletedRecipeRecordSchema
 from tests.ims_fixtures import _GenericDataFixture
-
+from src.server.models.remote_build_nodes import V3RemoteBuildNodeRecordSchema
 
 class V3FlaskTestClientFixture(Fixture):
     """ Test Fixture for preparing the Flask test client """
@@ -57,6 +57,12 @@ class V3DeletedPublicKeysDataFixture(_GenericDataFixture):
     schema = V3DeletedPublicKeyRecordSchema
     datastore = app.data['deleted_public_keys']
     id_field = 'id'
+
+
+class V3RemoteBuildNodesDataFixture(_GenericDataFixture):
+    schema = V3RemoteBuildNodeRecordSchema
+    datastore = app.data['remote_build_nodes']
+    id_field = 'xname'
 
 
 class V3ImagesDataFixture(_GenericDataFixture):

--- a/tests/v3/test_v3_jobs.py
+++ b/tests/v3/test_v3_jobs.py
@@ -44,10 +44,10 @@ from src.server.helper import ARTIFACT_LINK_TYPE_S3, S3Url
 from src.server.models.jobs import (KERNEL_FILE_NAME_ARM, KERNEL_FILE_NAME_X86,
                                     STATUS_TYPES)
 from tests.utils import check_error_responses
-from tests.v2.ims_fixtures import (V2FlaskTestClientFixture,
-                                   V2ImagesDataFixture, V2JobsDataFixture,
-                                   V2PublicKeysDataFixture,
-                                   V2RecipesDataFixture)
+#from tests.v2.ims_fixtures import (V2FlaskTestClientFixture,
+#                                   V2ImagesDataFixture, V2JobsDataFixture,
+#                                   V2PublicKeysDataFixture,
+#                                   V2RecipesDataFixture)
 from tests.v3.ims_fixtures import (V3FlaskTestClientFixture,
                                    V3ImagesDataFixture, V3JobsDataFixture,
                                    V3PublicKeysDataFixture,
@@ -55,9 +55,9 @@ from tests.v3.ims_fixtures import (V3FlaskTestClientFixture,
 
 
 # TODO: This tests v2 change to v3
-@mock.patch("src.server.v2.resources.jobs.client")
-@mock.patch("src.server.v2.resources.jobs.config")
-@mock.patch("src.server.v2.resources.jobs.utils")
+@mock.patch("src.server.v3.resources.jobs.client")
+@mock.patch("src.server.v3.resources.jobs.config")
+@mock.patch("src.server.v3.resources.jobs.utils")
 class TestV3JobEndpoint(TestCase):
     """
     Test the job/{job_id} endpoint (ims.v2.resources.jobs.JobResource)
@@ -65,7 +65,7 @@ class TestV3JobEndpoint(TestCase):
 
     def setUp(self):
         super(TestV3JobEndpoint, self).setUp()
-        self.app = self.useFixture(V2FlaskTestClientFixture()).client
+        self.app = self.useFixture(V3FlaskTestClientFixture()).client
         self.test_job_id = str(uuid.uuid4())
         self.data = {
             'job_type': "create",
@@ -83,8 +83,8 @@ class TestV3JobEndpoint(TestCase):
             'arch': "x86_64",
             'require_dkms': False,
         }
-        self.useFixture(V2JobsDataFixture(initial_data=self.data))
-        self.test_uri = '/jobs/{}'.format(self.data['id'])
+        self.useFixture(V3JobsDataFixture(initial_data=self.data))
+        self.test_uri = '/v3/jobs/{}'.format(self.data['id'])
         
     def tearDown(self):
         super(TestV3JobEndpoint, self).tearDown()
@@ -109,7 +109,7 @@ class TestV3JobEndpoint(TestCase):
 
     def test_get_404_bad_id(self, client_mock, config_mock, utils_mock):
         """ Test the artifacts/{artifact_id} resource retrieval with an unknown id """
-        response = self.app.get('/jobs/{}'.format(str(uuid.uuid4())))
+        response = self.app.get('/v3/jobs/{}'.format(str(uuid.uuid4())))
         check_error_responses(self, response, 404, ['status', 'title', 'detail'])
 
     def test_delete(self, client_mock, config_mock, utils_mock):
@@ -120,7 +120,7 @@ class TestV3JobEndpoint(TestCase):
 
     def test_delete_404_bad_id(self, client_mock, config_mock, utils_mock):
         """ Test the artifacts/{artifact_id} resource removal with an unknown id """
-        response = self.app.delete('/jobs/{}'.format(str(uuid.uuid4())))
+        response = self.app.delete('/v3/jobs/{}'.format(str(uuid.uuid4())))
         check_error_responses(self, response, 404, ['status', 'title', 'detail'])
 
     def test_delete_k8s_job_not_found_ok(self, utils_mock, config_mock, client_mock):
@@ -175,9 +175,9 @@ class TestV3JobEndpoint(TestCase):
                              'resource field "status" returned was not equal')
 
 # TODO: This tests v2 change to v3
-@mock.patch("src.server.v2.resources.jobs.client")
-@mock.patch("src.server.v2.resources.jobs.config")
-@mock.patch("src.server.v2.resources.jobs.utils")
+@mock.patch("src.server.v3.resources.jobs.client")
+@mock.patch("src.server.v3.resources.jobs.config")
+@mock.patch("src.server.v3.resources.jobs.utils")
 class TestV3JobsCollectionEndpoint(TestCase):
     """
     Test the jobs/ collection endpoint (ims.v2.resources.jobs.JobsCollection)
@@ -187,7 +187,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         super(TestV3JobsCollectionEndpoint, self).setUp()
         
         self.s3_stub = Stubber(app.app.s3)
-        self.test_uri = '/jobs'
+        self.test_uri = '/v3/jobs'
         self.app = app.app.test_client()
         self.test_recipe_id = str(uuid.uuid4())
         self.test_image_id = str(uuid.uuid4())
@@ -273,10 +273,10 @@ class TestV3JobsCollectionEndpoint(TestCase):
                 }
             ]
         }
-        self.test_jobs = self.useFixture(V2JobsDataFixture(initial_data=self.job_data)).datastore
-        self.test_public_keys = self.useFixture(V2PublicKeysDataFixture(initial_data=self.public_key_data)).datastore
-        self.recipes = self.useFixture(V2RecipesDataFixture(initial_data=self.recipe_data)).datastore
-        self.images = self.useFixture(V2ImagesDataFixture(initial_data=self.image_data)).datastore
+        self.test_jobs = self.useFixture(V3JobsDataFixture(initial_data=self.job_data)).datastore
+        self.test_public_keys = self.useFixture(V3PublicKeysDataFixture(initial_data=self.public_key_data)).datastore
+        self.recipes = self.useFixture(V3RecipesDataFixture(initial_data=self.recipe_data)).datastore
+        self.images = self.useFixture(V3ImagesDataFixture(initial_data=self.image_data)).datastore
         self.test_domain = 'https://api-gw-service-nmn.local'
         
     def tearDown(self):
@@ -293,7 +293,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_age_2wks(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?age=2w")
+        response = self.app.delete("/v3/jobs?age=2w")
         self.assertEqual(response.status_code, 204, 'status code was not 204')
         self.assertEqual(response.data, b'', 'resource returned was not empty')
 
@@ -303,7 +303,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_age_3days(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?age=3d")
+        response = self.app.delete("/v3/jobs?age=3d")
         self.assertEqual(response.status_code, 204, 'status code was not 204')
         self.assertEqual(response.data, b'', 'resource returned was not empty')
 
@@ -313,7 +313,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_status_error(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?status=error")
+        response = self.app.delete("/v3/jobs?status=error")
         self.assertEqual(response.status_code, 204, 'status code was not 204')
         self.assertEqual(response.data, b'', 'resource returned was not empty')
 
@@ -323,7 +323,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_status_success(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?status=success")
+        response = self.app.delete("/v3/jobs?status=success")
         self.assertEqual(response.status_code, 204, 'status code was not 204')
         self.assertEqual(response.data, b'', 'resource returned was not empty')
 
@@ -333,7 +333,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_status_invalid(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?status=invalid")
+        response = self.app.delete("/v3/jobs?status=invalid")
         self.assertEqual(response.status_code, 400, 'status code was not 400')
 
         # verify that all the jobs were deleted
@@ -342,8 +342,8 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_type_customize(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?job_type=customize")
-        response = self.app.delete("/jobs?job_type=customize")
+        response = self.app.delete("/v3/jobs?job_type=customize")
+        response = self.app.delete("/v3/jobs?job_type=customize")
         self.assertEqual(response.status_code, 204, 'status code was not 204')
         self.assertEqual(response.data, b'', 'resource returned was not empty')
 
@@ -353,7 +353,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_type_create(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?job_type=create")
+        response = self.app.delete("/v3/jobs?job_type=create")
         self.assertEqual(response.status_code, 204, 'status code was not 204')
         self.assertEqual(response.data, b'', 'resource returned was not empty')
 
@@ -363,7 +363,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
     def test_delete_jobs_type_invalid(self, utils_mock, config_mock, client_mock):
 
-        response = self.app.delete("/jobs?job_type=invalid")
+        response = self.app.delete("/v3/jobs?job_type=invalid")
         self.assertEqual(response.status_code, 400, 'status code was not 400')
 
         # verify that all the jobs were deleted
@@ -387,7 +387,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
             else:
                 self.assertEqual(response_data[key], self.job_data[key])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_enable_debug_false(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -412,7 +412,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         s3_mock.return_value = "http://localhost/path/to/file_abc.tgz"
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         response_data = json.loads(response.data)
@@ -429,10 +429,10 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name','arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_enable_debug_true(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -459,7 +459,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         s3_mock.return_value = "http://localhost/path/to/file_abc.tgz"
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         response_data = json.loads(response.data)
@@ -494,10 +494,10 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name','arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_ims_job_namespace(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -524,7 +524,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
 
         with mock.patch.dict('os.environ', {'DEFAULT_IMS_JOB_NAMESPACE': job_namespace}):
             self.s3_stub.activate()
-            response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+            response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
             self.s3_stub.deactivate()
 
         response_data = json.loads(response.data)
@@ -543,7 +543,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
     def test_post_create_with_ssh_container(self, utils_mock, config_mock, client_mock):
@@ -564,11 +564,11 @@ class TestV3JobsCollectionEndpoint(TestCase):
             ]
         }
 
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.assertEqual(response.status_code, 400, 'status code was not 400')
 
     @responses.activate
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_customize_with_out_ssh_container(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -620,7 +620,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         s3_mock.return_value = "http://localhost/path/to/file_abc.tgz"
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         response_data = json.loads(response.data)
@@ -641,11 +641,11 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
     @responses.activate
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_customize_with_ssh_container(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -711,7 +711,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         s3_mock.return_value = "http://localhost/path/to/file_abc.tgz"
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         response_data = json.loads(response.data)
@@ -745,7 +745,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
                                'ssh_containers', 'status', 'image_root_archive_name', 'initrd_file_name',
                                'kernel_file_name', 'resultant_image_id', 'kubernetes_namespace',
                                'kernel_parameters_file_name', 'arch', 'require_dkms', 'kubernetes_pvc',
-                               'job_mem_size'],
+                               'job_mem_size','remote_build_node'],
                               'returned keys not the same')
 
 
@@ -768,7 +768,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
             ]
         }
 
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         response_data = json.loads(response.data)
         self.assertEqual(response.status_code, 400, 'status code was not 400')
 
@@ -809,7 +809,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         response = self.app.post(self.test_uri, content_type='application/json', data=json.dumps(input_data))
         check_error_responses(self, response, 422, ['status', 'title', 'detail', 'errors'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_422_missing_image_root_archive_name(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where image_root_archive_name is missing """
@@ -831,7 +831,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.assertIn("image_root_archive_name", response.json["errors"],
                       "Expected image_root_archive_name to be listed in error detail")
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_422_image_root_archive_name_is_blank(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where image_root_archive_name is blank """
@@ -854,7 +854,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.assertIn("image_root_archive_name", response.json["errors"],
                       "Expected image_root_archive_name to be listed in error detail")
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_422_initrd_file_name_is_blank(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where initrd_file_name is blank """
@@ -876,7 +876,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.assertIn("initrd_file_name", response.json["errors"],
                       "Expected initrd_file_name to be listed in error detail")
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_422_invalid_job_type(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where job type is invalid """
@@ -897,7 +897,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.assertIn("job_type", response.json["errors"],
                       "Expected job_type to be listed in error detail")
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_400_invalid_create_artifact_id(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where the artifact_id is invalid for create case """
@@ -916,7 +916,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         response = self.app.post(self.test_uri, content_type='application/json', data=json.dumps(input_data))
         check_error_responses(self, response, 400, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_422_create_artifact_not_in_s3(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -937,12 +937,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.s3_stub.add_client_error('head_object')
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 422, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_422_customize_manifest_not_in_s3(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where the manifest.json is not in s3  """
@@ -963,12 +963,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.s3_stub.add_client_error('head_object')
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 422, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_400_customize_manifest_does_not_have_rootfs(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where the manifest.json does not list a rootfs object  """
@@ -1022,12 +1022,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         )
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 400, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_400_customize_manifest_bad_version(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where the manifest.json has an unknown version  """
@@ -1069,12 +1069,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         )
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 400, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_400_customize_manifest_no_version(self, mock_open, utils_mock, config_mock, client_mock):
 
@@ -1116,12 +1116,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         )
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 400, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     def test_post_422_customize_rootfs_not_in_s3(self, mock_open, utils_mock, config_mock, client_mock):
         """ Test case where the rootfs object is not in s3 """
@@ -1161,12 +1161,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         self.s3_stub.add_client_error('head_object')
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 422, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_400_customize_cannot_create_presigned_url(self, s3_mock, mock_open, utils_mock,
@@ -1219,12 +1219,12 @@ class TestV3JobsCollectionEndpoint(TestCase):
         s3_mock.side_effect = ClientError(parsed_response, "generate_presigned_url")
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 400, ['status', 'title', 'detail'])
 
-    @mock.patch("src.server.v2.resources.jobs.open", new_callable=mock.mock_open,
+    @mock.patch("src.server.v3.resources.jobs.open", new_callable=mock.mock_open,
                 read_data='{"metadata":{"name":"foo"}}')
     @mock.patch("src.server.app.app.s3.generate_presigned_url")
     def test_post_400_public_key_invalid(self, s3_mock, mock_open, utils_mock, config_mock, client_mock):
@@ -1248,7 +1248,7 @@ class TestV3JobsCollectionEndpoint(TestCase):
         s3_mock.return_value = "http://localhost/path/to/file_abc.tgz"
 
         self.s3_stub.activate()
-        response = self.app.post('/jobs', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/jobs', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 400, ['status', 'title', 'detail'])

--- a/tests/v3/test_v3_public_keys.py
+++ b/tests/v3/test_v3_public_keys.py
@@ -119,7 +119,7 @@ class TestV3PublicKeyEndpoint(TestV3PublicKeyBase):
 
     def test_delete_404_bad_id(self):
         """ Test the artifacts/{artifact_id} resource removal with an unknown id """
-        response = self.app.delete('/public-keys/{}'.format(str(uuid.uuid4())))
+        response = self.app.delete('/v3/public-keys/{}'.format(str(uuid.uuid4())))
         check_error_responses(self, response, 404, ['status', 'title', 'detail'])
 
 

--- a/tests/v3/test_v3_recipes.py
+++ b/tests/v3/test_v3_recipes.py
@@ -175,7 +175,7 @@ class TestV3RecipeEndpoint(TestV3RecipeBase):
 
     def test_get_404_bad_id(self):
         """ Test the recipes/{recipe_id} resource retrieval with an unknown id """
-        response = self.app.get('/recipes/{}'.format(str(uuid.uuid4())))
+        response = self.app.get('/v3/recipes/{}'.format(str(uuid.uuid4())))
         check_error_responses(self, response, 404, ['status', 'title', 'detail'])
 
     def test_delete(self):
@@ -217,7 +217,7 @@ class TestV3RecipeEndpoint(TestV3RecipeBase):
 
     def test_delete_404_bad_id(self):
         """ Test the recipes/{recipe_id} resource removal with an unknown id """
-        response = self.app.delete('/recipes/{}'.format(str(uuid.uuid4())))
+        response = self.app.delete('/v3/recipes/{}'.format(str(uuid.uuid4())))
         check_error_responses(self, response, 404, ['status', 'title', 'detail'])
 
     def test_patch(self):
@@ -413,7 +413,7 @@ class TestV3RecipesCollectionEndpoint(TestV3RecipeBase):
             self.s3_stub.add_response('head_object', {"ETag": link["etag"]}, expected_params)
 
         self.s3_stub.activate()
-        response = self.app.post('/recipes', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/recipes', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         response_data = json.loads(response.data)
@@ -543,7 +543,7 @@ class TestV3RecipesCollectionEndpoint(TestV3RecipeBase):
         self.s3_stub.add_client_error('head_object')
 
         self.s3_stub.activate()
-        response = self.app.post('/recipes', content_type='application/json', data=json.dumps(input_data))
+        response = self.app.post('/v3/recipes', content_type='application/json', data=json.dumps(input_data))
         self.s3_stub.deactivate()
 
         check_error_responses(self, response, 422, ['status', 'title', 'detail'])

--- a/tests/v3/test_v3_remote_build_nodes.py
+++ b/tests/v3/test_v3_remote_build_nodes.py
@@ -1,0 +1,147 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for resources/remote_build_nodes.py
+"""
+import json
+import unittest
+
+import datetime
+import uuid
+from testtools import TestCase
+from testtools.matchers import HasLength
+
+from tests.v3.ims_fixtures import V3FlaskTestClientFixture, V3RemoteBuildNodesDataFixture
+from tests.utils import check_error_responses
+
+
+class TestV3RemoteBuildNodesEndpoint(TestCase):
+    """
+    Test the remote-build-nodes/{remote_build_node_xname} endpoint (ims.v3.resources.remote_build_node.RemoteBuildNodeResource)
+    """
+
+    def setUp(self):
+        super(TestV3RemoteBuildNodesEndpoint, self).setUp()
+        self.app = self.useFixture(V3FlaskTestClientFixture()).client
+        self.data = {
+            'xname': self.getUniqueString()
+        }
+        self.useFixture(V3RemoteBuildNodesDataFixture(initial_data=self.data))
+        self.test_uri = '/v3/remote-build-nodes/{}'.format(self.data['xname'])
+
+    def test_get(self):
+        """ Test the remote-build-nodes/{remote_build_node_xname} resource retrieval """
+        response = self.app.get(self.test_uri)
+        self.assertEqual(response.status_code, 200, 'status code was not 200')
+        response_data = json.loads(response.data)
+        self.assertEqual(set(self.data.keys()).difference(response_data.keys()), set(), 'returned keys not the same')
+        for key in response_data:
+            self.assertEqual(response_data[key], self.data[key],
+                                'resource field "{}" returned was not equal'.format(key))
+
+    def test_get_404_bad_id(self):
+        """ Test the artifacts/{artifact_id} resource retrieval with an unknown id """
+        response = self.app.get('/v3/remote-build-nodes/{}'.format(str(uuid.uuid4())))
+        check_error_responses(self, response, 404, ['status', 'title', 'detail'])
+
+    def test_delete(self):
+        """ Test the artifacts/{artifact_id} resource removal """
+        response = self.app.delete(self.test_uri)
+        self.assertEqual(response.status_code, 204, 'status code was not 204')
+        self.assertEqual(response.data, b'', 'resource returned was not empty')
+
+    def test_delete_404_bad_id(self):
+        """ Test the artifacts/{artifact_id} resource removal with an unknown id """
+        response = self.app.delete('/v3/remote-build-nodes/{}'.format(str(uuid.uuid4())))
+        check_error_responses(self, response, 404, ['status', 'title', 'detail'])
+
+
+class TestV3RemoteBuildNodesCollectionEndpoint(TestCase):
+    """
+    Test the remote-build-nodes/ collection endpoint (ims.v3.resources.remote_build_nodes.RemoteBuildNodesCollection)
+    """
+
+    def setUp(self):
+        super(TestV3RemoteBuildNodesCollectionEndpoint, self).setUp()
+        self.test_uri = '/v3/remote-build-nodes'
+        self.app = self.useFixture(V3FlaskTestClientFixture()).client
+        self.data = {
+            'xname': self.getUniqueString()
+        }
+        self.test_remote_build_nodes = self.useFixture(V3RemoteBuildNodesDataFixture(initial_data=self.data)).datastore
+
+    def test_get(self):
+        """ Test happy path GET """
+        response = self.app.get(self.test_uri)
+        self.assertEqual(response.status_code, 200, 'status code was not 200')
+        self.assertThat(json.loads(response.data), HasLength(1), 'collection did not have an entry')
+        response_data = json.loads(response.data)[0]
+        for key in self.data:
+            self.assertEqual(response_data[key], self.data[key])
+
+    def test_post(self):
+        """ Test happy path POST """
+        input_name = self.getUniqueString()
+        input_data = {'xname': input_name}
+
+        response = self.app.post('/v3/remote-build-nodes', content_type='application/json', data=json.dumps(input_data))
+        response_data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201, 'status code was not 201')
+        self.assertEqual(response_data['xname'], input_name, 'artifact name was not set properly')
+        self.assertItemsEqual(response_data.keys(),
+                              ['xname'],
+                              'returned keys not the same')
+
+    def test_post_400_no_input(self):
+        """ Test a POST request with no input provided by the client """
+        response = self.app.post(self.test_uri, content_type='application/json', data=json.dumps({}))
+        check_error_responses(self, response, 400, ['status', 'title', 'detail'])
+
+    def test_post_422_improper_type_inputs(self):
+        """ Test a POST request with invalid data provided by the client (bad types) """
+        input_data = {'xname': self.getUniqueInteger()}
+        response = self.app.post(self.test_uri, content_type='application/json', data=json.dumps(input_data))
+        check_error_responses(self, response, 422, ['status', 'title', 'detail', 'errors'])
+
+    def test_post_422_unknown_field(self):
+        """ Test a POST request with a field that is not valid for the request """
+        input_name = self.getUniqueString()
+        input_data = {
+            'xname': input_name,
+            'invalid_field': str(uuid.uuid4())  # invalid
+        }
+        response = self.app.post(self.test_uri, content_type='application/json', data=json.dumps(input_data))
+        check_error_responses(self, response, 422, ['status', 'title', 'detail', 'errors'])
+
+    def test_post_422_name_is_blank(self):
+        """ Test case where the name is blank """
+        input_data = {
+            'xname': ""
+        }
+        response = self.app.post(self.test_uri, content_type='application/json', data=json.dumps(input_data))
+        check_error_responses(self, response, 422, ['status', 'title', 'detail', 'errors'])
+        self.assertIn("xname", response.json["errors"], "Expected xname to be listed in error detail")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary and Scope

Update IMS to handle adding/removing/querying remote-build-nodes and add them to the job templating.

## Issues and Related PRs

* Resolves [CASMCMS-8795](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8795)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed new helm chart and verified the new API works and kicks off builds with the remote-build-node option if a node is defined and matches the job criteria.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Medium size risk as we are adding a new API and it is impacting the job creation.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

