### PR TITLE
CASMTRIAGE-6368/6292 - include ims-sshd fix for sftp, increase default mem requirements/limits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.11.0] - 2023-10-05
+### Changed
+- CASMTRIAGE-6368 - include ims-sshd fix for sftp access to customize jobs.
+- CASMTRIAGE-6292 - increase default mem request/limits yet again.
+
 ## [3.10.1] - 2023-10-05
 ### Changed
 - CASMCMS-8828 - increase the default mem requests and limits on jobs.

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
   DEFAULT_IMS_IMAGE_SIZE: "15"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
-  DEFAULT_IMS_JOB_MEM_SIZE: "5"
+  DEFAULT_IMS_JOB_MEM_SIZE: "8"
 
   JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN: "{{ .Values.customer_access.shasta_domain }}"
   JOB_CUSTOMER_ACCESS_SUBNET_NAME: "{{ .Values.customer_access.subnet_name }}"

--- a/src/server/v2/resources/jobs.py
+++ b/src/server/v2/resources/jobs.py
@@ -699,7 +699,7 @@ class V2JobCollection(V2BaseJobResource):
             "limit_gb": str(int(new_job.build_env_size) * 3) + "Gi",
             "pvc_gb": str(int(new_job.build_env_size) * 5) + "Gi",
             "job_mem_size": str(new_job.job_mem_size) + "Gi",
-            "job_mem_limit": str(int(new_job.job_mem_size) * 3) + "Gi",
+            "job_mem_limit": str(int(new_job.job_mem_size) * 5) + "Gi",
             "download_url": artifact_info["url"],  # pylint: disable=unsubscriptable-object
             "download_md5sum": artifact_info["md5sum"],  # pylint: disable=unsubscriptable-object
             "public_key": public_key_data,

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -705,7 +705,7 @@ class V3JobCollection(V3BaseJobResource):
             "limit_gb": str(int(new_job.build_env_size) * 3) + "Gi",
             "pvc_gb": str(int(new_job.build_env_size) * 5) + "Gi",
             "job_mem_size": str(new_job.job_mem_size) + "Gi",
-            "job_mem_limit": str(int(new_job.job_mem_size) * 3) + "Gi",
+            "job_mem_limit": str(int(new_job.job_mem_size) * 5) + "Gi",
             "download_url": artifact_info["url"],  # pylint: disable=unsubscriptable-object
             "download_md5sum": artifact_info["md5sum"],  # pylint: disable=unsubscriptable-object
             "public_key": public_key_data,

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -8,4 +8,4 @@ image: cray-ims-kiwi-ng-opensuse-x86_64-builder
 
 image: cray-ims-sshd
     major: 1
-    minor: 8
+    minor: 9


### PR DESCRIPTION
## Summary and Scope

Integrate the changes from ims-sshd to fix sftp use on customize jobs, and increase the default memory requirements / limits to handle bigger images work without changing IMS defaults.

## Issues and Related PRs
* Resolves [CASMTRIAGE-6368](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6368)
* Resolves [CASMTRIAGE-6292](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6292)

## Testing
### Tested on:
  * `Mug`

### Test description:

I did a clean helm install of the new IMS service and tested the ssh/sftp access on jobs, and verified the new updated memory settings are present.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

The changes are small, so the only risks are the normal ones associated with last-minute changes to a release.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

