### PR TITLE
CASMTRIAGE-6426 update default IMS pvc size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.12.0] - 2023-12-13
+### Changed
+- CASMTRIAGE-6426 Increased default IMS pvc size
+
 ## [3.11.0] - 2023-10-05
 ### Changed
 - CASMTRIAGE-6368 - include ims-sshd fix for sftp access to customize jobs.

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -31,7 +31,7 @@ metadata:
 data:
   API_GATEWAY_HOSTNAME: "{{ .Values.api_gw.api_gw_service_name }}.{{ .Values.api_gw.api_gw_service_namespace }}.svc.cluster.local"
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
-  DEFAULT_IMS_IMAGE_SIZE: "15"
+  DEFAULT_IMS_IMAGE_SIZE: "30"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
   DEFAULT_IMS_JOB_MEM_SIZE: "8"
 


### PR DESCRIPTION
## Summary and Scope

Needed to increase the size of PVC for IMS due to resource constraints when building large images.

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6426

## Testing

_List the environments in which these changes were tested._

### Tested on:

drax

### Test description:
Increased the PVC size which unblocked the resource constraint.

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

