### PR TITLE
CASMCMS-8925 - better error handling for vault access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - CASMCMS-8795 - add remote-build-nodes API.
+- CASMCMS-8925 - ims service in CLBO when vault is not accessible.
 
 ## [3.13.0] - 2024-02-22
 ### Dependencies


### PR DESCRIPTION
## Summary and Scope

There was a case where vault was not accessible and the ims service was in CLBO due to unhandled exceptions in valut.py. This is code that is just trying to access ssh keys for remote build nodes. This is not used by all deployments, so should not take down the entire service.

This code does more error checking / handling to not crash if vault is not working correctly.

## Issues and Related PRs
* Resolves [CASMCMS-8925](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8925)

## Testing
### Tested on:
  * `Baldar`

### Test description:

I created an image with a simulated vault failure (vault was fixed on the machine by the time I was testing) and verified that the condition was handled cleanly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

