### PR TITLE
CASMCMS-8950: Fix Kubernetes client initialization in shasta_s3_creds module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.1] - 2024-03-21
+### Fixed
+- CASMCMS-8950: Fixed loading Kubernetes configuration data in the shasta_s3_creds module
+
 ## [3.14.0] - 2024-03-01
 ### Added
 - CASMCMS-8795 - add remote-build-nodes API.

--- a/lib/shasta_s3_creds.py
+++ b/lib/shasta_s3_creds.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,8 +31,6 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from kubernetes import client, config
-from kubernetes.client.api_client import ApiClient
-from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
 
@@ -127,9 +125,7 @@ def run_module():
     except ConfigException:
         config.load_kube_config()
 
-    configuration = Configuration()
-    k8sclient = ApiClient(configuration=configuration)
-    coreapi = client.CoreV1Api(k8sclient)
+    coreapi = client.CoreV1Api()
 
     # Read the secret
     try:


### PR DESCRIPTION
This addresses the same problem (in the same module) that Ryan addressed in cray-aee with [CASMTRIAGE-6799](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6799). The PR content is identical:
https://github.com/Cray-HPE/ansible-execution-environment/pull/64

This addresses an incompatibility with the updated Kubernetes module version.

I verified that this module fails on CSM 1.6 systems inside the IMS pod, but that it works with this fix.