### PR TITLE
CASMCMS-9001: Pin pytest version to prevent unit test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.2] - 2024-05-16
+### Dependencies
+- Pin `pytest` to 8.1.1 to prevent unit test failures
+
 ## [3.14.1] - 2024-03-21
 ### Fixed
 - CASMCMS-8950: Fixed loading Kubernetes configuration data in the shasta_s3_creds module

--- a/constraints.txt
+++ b/constraints.txt
@@ -24,6 +24,7 @@ marshmallow==3.0.0b16
 oauthlib==2.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
+pytest==8.1.1
 python-dateutil==2.8.2
 pytz==2018.4
 PyYAML==6.0.1


### PR DESCRIPTION
IMS rebuilds in `master` branch started failing because the unit tests began to fail. Investigation revealed that the version of `pytest` was not pinned, and the tests started failing when it went from 8.1.1 to 8.2.0. I have verified that pinning it to 8.1.1 avoids the failures.