### PR TITLE
CASMCMS-9001: Pin pytest to prevent unit test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [3.8.6] - 2024-05-16
+### Dependencies
+- Pin `pytest` to 8.1.1 to prevent unit test failures
+
 ## [3.8.5] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,6 +22,7 @@ marshmallow==3.0.0b16
 oauthlib==2.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.2
+pytest==8.1.1
 python-dateutil==2.8.1
 pytz==2018.4
 PyYAML==6.0.1


### PR DESCRIPTION
(cherry picked from commit 572918cc97c14d3721b0cb46059faf9e0a391a25)
