### PR TITLE
CASMCMS-8976 - include updated kiwi-builder version to get new DST signing key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.15.0] - 2024-05-20
+### Dependencies
+- CASMCMS-8976 - include updated kiwi-builder version that has new DST signing keys.
+
 ## [3.14.2] - 2024-05-16
 ### Dependencies
 - Pin `pytest` to 8.1.1 to prevent unit test failures

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -4,7 +4,7 @@ image: cray-ims-utils
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
-    minor: 7
+    minor: 8
 
 image: cray-ims-sshd
     major: 1


### PR DESCRIPTION
## Summary and Scope

DST has published a new signing key for zypper repos that we include in the kiwi-builder image. This changes updates the version that IMS includes to get that fix incorporated.

## Issues and Related PRs
* Resolves [CASMCMS-8976](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8976)

## Testing

Tested under https://github.com/Cray-HPE/ims-kiwi-ng-opensuse-x86_64-builder/pull/73

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

