### PR TITLE
CASMCMS-8977 - refetch ssh key if not present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - CASMCMS-8979 - add a status endpoint for the remote build nodes.
+- CASMCMS-8977 - check that the ssh key is present each time spawning a remote job.
 
 ## [3.16.2] - 2024-07-25
 ### Dependencies

--- a/src/server/vault.py
+++ b/src/server/vault.py
@@ -109,6 +109,19 @@ def get_exportable_key(app):
         app.logger.error("Failed to get exportable key from vault: %s", err)
     return None
 
+def test_private_key_file(app) -> bool:
+    # If the private key is present, just return
+    if os.path.isfile('id_ecdsa'):
+        app.logger.info("Private ssh key file present")
+        return True
+    
+    # Private key is not present, try to fetch or regenerate it
+    app.logger.info("Private ssh key file not present - attempting to refetch...")
+    remote_node_key_setup(app)
+
+    # return if the key file is present
+    return os.path.isfile('id_ecdsa')
+
 def export_private_key(app, private_key):
     # This will throw an error on attempting to write a null
     if private_key == None:


### PR DESCRIPTION
## Summary and Scope

There are a few cases where on initialization of the IMS service, the ssh key is not able to be fetched from vault. That would result in the remote build nodes being inaccessible until the service was restarted.

With this change, each time the remote nodes would be accessed (either to find one for creating a job, or to get remote build node status information) it checks if the key is present. If it isn't present, it attempts to fetch it again. 

## Issues and Related PRs
* Resolves [CASMCMS-8977](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8977)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new container on Mug and manually deleted the key file inside the container to simulate the key not getting fetched on initialization. After that I executed remote node operations that require the key and verified that the key was correctly fetched and the operations proceeded correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change, as it only re-attempts an existing operation if the key file is missing.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

