### PR TITLE
CASMCMS-8979 - update status unknown jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - CASMCMS-8979 - add a status endpoint for the remote build nodes.
+- CASMCMS-8979-v2 - clean up status object.
 - CASMCMS-8977 - check that the ssh key is present each time spawning a remote job.
 
 ## [3.16.2] - 2024-07-25

--- a/src/server/models/remote_build_nodes.py
+++ b/src/server/models/remote_build_nodes.py
@@ -42,20 +42,16 @@ from src.server.helper import ARCH_ARM64, ARCH_X86_64
 class RemoteNodeStatus:
     """ Object to hold the current status of a remote build node """
 
-    # status variable to represent and unknown number of jobs on a node
-    UNKNOWN_NUM_JOBS = 10000
-
     def __init__(self, xname: str) -> None:
         self.xname = xname
         self.sshStatus = "Unknown"
         self.podmanStatus = "Unknown"
         self.nodeArch = "Unknown"
-        self.numCurrentJobs = self.UNKNOWN_NUM_JOBS
+        self.numCurrentJobs = -1
         self.ableToRunJobs = False
 
     def toJson(self):
         return self.__dict__
-        #return json.dumps(self, default=lambda o: o.__dict__)
 
 class V3RemoteBuildNodeRecord:
     """ The RemoteBuildNodeRecord object """


### PR DESCRIPTION
## Summary and Scope

Clean up the default value of number of jobs for the remote build node status object. Using 10000 was weird - made it -1 for unknown.

## Issues and Related PRs
* Resolves [CASMCMS-8979](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8979)

## Testing
### Tested on:
  * `Mug`

### Test description:

Updated to the new image and tested with valid and invalid remote build nodes. Ran multiple jobs, make sure the number of current jobs was correct.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

