### PR TITLE
CASMINST-6602 - enable dkms by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8979 - add a status endpoint for the remote build nodes.
 - CASMCMS-8979-v2 - clean up status object.
 - CASMCMS-8977 - check that the ssh key is present each time spawning a remote job.
+- CASMINST-6602 - enable dkms by default.
 
 ### Dependencies
 - CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -88,7 +88,7 @@ customer_access:
   subnet_name: "cmn"
 
 jobs:
-  enable_dkms: false
+  enable_dkms: true
   kata_runtime: "kata-qemu"
   aarch64_runtime: "kata-qemu"
 

--- a/src/server/models/jobs.py
+++ b/src/server/models/jobs.py
@@ -85,7 +85,7 @@ class V2JobRecord:
                  kubernetes_configmap=None, enable_debug=False,
                  build_env_size=None, image_root_archive_name=None, kernel_file_name=None,
                  initrd_file_name=None, resultant_image_id=None, ssh_containers=None,
-                 kubernetes_namespace=None, kernel_parameters_file_name=None, require_dkms=False,
+                 kubernetes_namespace=None, kernel_parameters_file_name=None, require_dkms=True,
                  arch=None, job_mem_size=None, kubernetes_pvc=None, remote_build_node=""):
         # Supplied
         # v2.0
@@ -163,7 +163,7 @@ class V2JobRecordInputSchema(Schema):
     ssh_containers = fields.List(fields.Nested(SshContainerInputSchema()), allow_none=True)
 
     # v2.1
-    require_dkms = fields.Boolean(required=False, load_default=False, dump_default=False,
+    require_dkms = fields.Boolean(required=False, load_default=True, dump_default=True,
                                   metadata={"metadata": {"description": "Job requires the use of dkms"}})
 
     # v2.2

--- a/src/server/models/recipes.py
+++ b/src/server/models/recipes.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -56,7 +56,7 @@ class V2RecipeRecord:
 
     # pylint: disable=W0622
     def __init__(self, name, recipe_type, linux_distribution, link=None, id=None, created=None,
-                 template_dictionary=None, require_dkms=False, arch=ARCH_X86_64):
+                 template_dictionary=None, require_dkms=True, arch=ARCH_X86_64):
         # Supplied
         self.name = name
         self.link = link
@@ -91,7 +91,7 @@ class V2RecipeRecordInputSchema(Schema):
     template_dictionary = fields.List(fields.Nested(RecipeKeyValuePair()), required=False, allow_none=True)
 
     # v2.2
-    require_dkms = fields.Boolean(load_default=False, dump_default=False,
+    require_dkms = fields.Boolean(load_default=True, dump_default=True,
                                   metadata={"metadata": {"description": "Recipe requires the use of dkms"}})
     arch = fields.Str(required=False, metadata={"metadata": {"description": "Architecture of the recipe"}},
                           validate=OneOf([ARCH_ARM64,ARCH_X86_64]), load_default=ARCH_X86_64, dump_default=ARCH_X86_64)
@@ -126,6 +126,6 @@ class V2RecipeRecordPatchSchema(Schema):
     arch = fields.Str(required=False, validate=OneOf([ARCH_ARM64,ARCH_X86_64]),
                       load_default=ARCH_X86_64, dump_default=ARCH_X86_64,
                       metadata={"metadata": {"description": "Architecture of the recipe"}})
-    require_dkms = fields.Boolean(required=False, load_default=False, dump_default=False,
+    require_dkms = fields.Boolean(required=False, load_default=True, dump_default=True,
                                   metadata={"metadata": {"description": "Recipe requires the use of dkms"}})
     template_dictionary = fields.List(fields.Nested(RecipeKeyValuePair()), required=False, allow_none=True)

--- a/src/server/v2/resources/jobs.py
+++ b/src/server/v2/resources/jobs.py
@@ -97,7 +97,7 @@ class V2BaseJobResource(Resource):
         # {job.id}.ims.{job_customer_access_subnet_name}.{job_customer_access_network_domain}"
         self.job_customer_access_subnet_name = os.environ.get("JOB_CUSTOMER_ACCESS_SUBNET_NAME", "cmn")
         self.job_customer_access_network_domain = os.environ.get("JOB_CUSTOMER_ACCESS_NETWORK_DOMAIN", "shasta.local")
-        self.job_enable_dkms = os.getenv("JOB_ENABLE_DKMS", 'False').lower() in ('true', '1', 't')
+        self.job_enable_dkms = os.getenv("JOB_ENABLE_DKMS", 'True').lower() in ('true', '1', 't')
 
         # NOTE: make sure this isn't a non-zero length string of spaces
         self.job_kata_runtime = os.getenv("JOB_KATA_RUNTIME", "kata-qemu").strip()
@@ -659,14 +659,17 @@ class V2JobCollection(V2BaseJobResource):
             current_app.logger.info(f" NOTE: aarch64 architecture requires dkms")
             new_job.require_dkms = True
         elif userSpecifiedDKMS==None:
-            if self.job_enable_dkms:
+            # if the user didn't specify for the job, look for defaults
+            if new_job.job_type == JOB_TYPE_CREATE:
+                # Let the setting from the recipe flow through if the user has not specified otherwise
+                if artifact_record.require_dkms != self.job_enable_dkms:
+                    current_app.logger.info(f"Overriding require_dkms based on recipe setting")
+                current_app.logger.info(f"Setting require_dkms based on recipe setting: {artifact_record.require_dkms}")
+                new_job.require_dkms = artifact_record.require_dkms
+            elif not self.job_enable_dkms:
                 # use the default from the ims-config config map
                 current_app.logger.info(f"Setting require_dkms based on ims-config setting")
-                new_job.require_dkms = True
-            elif new_job.job_type == JOB_TYPE_CREATE and artifact_record.require_dkms:
-                # Let the setting from the recipe flow through if the user has not specified otherwise
-                current_app.logger.info(f"Overriding require_dkms based on recipe setting")
-                new_job.require_dkms = True
+                new_job.require_dkms = False
 
         # get the public key information
         public_key_data, problem = V2JobCollection.get_public_key_data(log_id, new_job.public_key_id)

--- a/src/server/v3/models/recipes.py
+++ b/src/server/v3/models/recipes.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ class V3DeletedRecipeRecord(V2RecipeRecord):
     # pylint: disable=W0622
     def __init__(self, name, recipe_type, linux_distribution,
                  link=None, id=None, created=None, deleted=None,
-                 template_dictionary=None, require_dkms=False, arch=ARCH_X86_64):
+                 template_dictionary=None, require_dkms=True, arch=ARCH_X86_64):
         # Supplied
         self.deleted = deleted or datetime.datetime.now()
         super().__init__(name, recipe_type=recipe_type, linux_distribution=linux_distribution,


### PR DESCRIPTION
## Summary and Scope
There was a request by cos to have the require-dkms default to 'true' instead of 'false' like it originally released. This changes the defaults and had to modify the logic a little bit to get it right for integrating with the 'require_dkms' flag in the recipe records.

## Issues and Related PRs
* Resolves [CASMINST-6602](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6602)

## Testing
### Tested on:

  * `Mug`

### Test description:

I deployed the new helm chart to ensure the correct default value is applied to the ims-config settings. I then tested each combination of global and per record settings to make sure the correct use of dkms was determined in each scenario.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Fairly low risk and there are workarounds if the default settings are not what the user wants.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
