### PR TITLE
CASMTRIAGE-7169 - job memory size was not getting picked up correctly from ims configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8979 - add a status endpoint for the remote build nodes.
 - CASMCMS-8979-v2 - clean up status object.
 - CASMCMS-8977 - check that the ssh key is present each time spawning a remote job.
+- CASMTRIAGE-7169 - job memory size was not getting picked up correctly from the ims configuration settings.
 
 ### Dependencies
 - CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability

--- a/src/server/models/jobs.py
+++ b/src/server/models/jobs.py
@@ -167,7 +167,7 @@ class V2JobRecordInputSchema(Schema):
                                   metadata={"metadata": {"description": "Job requires the use of dkms"}})
 
     # v2.2
-    job_mem_size = fields.Integer(load_default=1, dump_default=1,
+    job_mem_size = fields.Integer(dump_default=1, required=False,
                                   validate=Range(min=1, error="build_env_size must be greater than or equal to 1"),
                                   metadata={"metadata": {"description": "Approximate working memory in GiB to reserve for the build job "
                                     "environment (loosely proportional to the final image size)"}})


### PR DESCRIPTION
## Summary and Scope

There was a bug where the default job size settings in the ims configuration were not getting picked up correctly. This meant that all values were defaulting to 1. This fixes it so the default is applied if the user does not supply a value.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7169](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7169)

## Testing
### Tested on:

  * `Mug`

### Test description:

I loaded the new image and verified that the correct default value is getting loaded from the ims configuration and is flowing through to the job being created.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk bug fix.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

