### PR TITLE
CASMCMS-9040 - pick up new ims-utils to resolve file permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8977 - check that the ssh key is present each time spawning a remote job.
 - CASMINST-6602 - enable dkms by default.
 - CASMTRIAGE-7169 - job memory size was not getting picked up correctly from the ims configuration settings.
+- CASMCMS-9040 - change read/write permissions of recipe config files output in image.
 
 ### Dependencies
 - CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,6 +1,6 @@
 image: cray-ims-utils
     major: 2
-    minor: 13
+    minor: 14
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1


### PR DESCRIPTION
## Summary and Scope

There were configuration file from the recipe being included in the final kiwi image. These files sometimes would contain sensitive information, but were globally readable. This fix changes the permissions on the dir and files to only be readable by root.  The change is actually in ims-utils, this picks up the new version.

## Issues and Related PRs
* Resolves [CASMCMS-9040](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9040)

## Testing
### Tested on:
  * `Tyr`

### Test description:

Installed on Tyr - built recipes, verified the resulting dir and files had the correct permissions set.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk change.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

