### PR TITLE
CASMTRIAGE-7252: Increase DEFAULT_IMS_IMAGE_SIZE from 30 to 60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMTRIAGE-7252: Increase DEFAULT_IMS_IMAGE_SIZE from 30 to 60.
+
 ## [3.17.2] - 2024-09-13
 ### Added
 - CASMTRIAGE-6953: Added comment to `src/server/app.py` noting dependency of IMS import tool in `docs-csm`

--- a/kubernetes/cray-ims/templates/configmap.yaml
+++ b/kubernetes/cray-ims/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ metadata:
 data:
   API_GATEWAY_HOSTNAME: "{{ .Values.api_gw.api_gw_service_name }}.{{ .Values.api_gw.api_gw_service_namespace }}.svc.cluster.local"
   CA_CERT: "/mnt/ca-vol/certificate_authority.crt"
-  DEFAULT_IMS_IMAGE_SIZE: "30"
+  DEFAULT_IMS_IMAGE_SIZE: "60"
   DEFAULT_IMS_JOB_NAMESPACE: "{{ .Values.ims_config.cray_ims_job_namespace }}"
   DEFAULT_IMS_JOB_MEM_SIZE: "8"
 

--- a/src/server/models/jobs.py
+++ b/src/server/models/jobs.py
@@ -69,10 +69,9 @@ ARCH_TO_KERNEL_FILE_NAME = dict({
     ARCH_X86_64: KERNEL_FILE_NAME_X86
 })
 
-
 DEFAULT_INITRD_FILE_NAME = 'initrd'
-DEFAULT_IMAGE_SIZE = os.environ.get("DEFAULT_IMS_IMAGE_SIZE", 15)
-DEFAULT_JOB_MEM_SIZE = os.environ.get("DEFAULT_IMS_JOB_MEM_SIZE", 1)
+DEFAULT_IMAGE_SIZE = os.environ.get("DEFAULT_IMS_IMAGE_SIZE", "60")
+DEFAULT_JOB_MEM_SIZE = os.environ.get("DEFAULT_IMS_JOB_MEM_SIZE", "8")
 DEFAULT_KERNEL_PARAMETERS_FILE_NAME = 'kernel-parameters'
 
 # pylint: disable=R0902
@@ -146,7 +145,7 @@ class V2JobRecordInputSchema(Schema):
                                          validate=Length(min=1, error="image_root_archive_name field must not be blank"))
     enable_debug = fields.Boolean(load_default=False,dump_default=False,
                                   metadata={"metadata": {"description": "Whether to enable debugging of the job"}})
-    build_env_size = fields.Integer(load_default=15,dump_default=15,
+    build_env_size = fields.Integer(load_default=60,dump_default=60,
                                     metadata={"metadata": {"description": "Approximate disk size in GiB to reserve for the image build environment (usually 2x final image size)"}},
                                     validate=Range(min=1, error="build_env_size must be greater than or equal to 1"))
     kernel_file_name = fields.Str(metadata={"metadata": {"description": "Name of the kernel file to extract and upload"}})
@@ -167,7 +166,7 @@ class V2JobRecordInputSchema(Schema):
                                   metadata={"metadata": {"description": "Job requires the use of dkms"}})
 
     # v2.2
-    job_mem_size = fields.Integer(dump_default=1, required=False,
+    job_mem_size = fields.Integer(dump_default=8, required=False,
                                   validate=Range(min=1, error="build_env_size must be greater than or equal to 1"),
                                   metadata={"metadata": {"description": "Approximate working memory in GiB to reserve for the build job "
                                     "environment (loosely proportional to the final image size)"}})


### PR DESCRIPTION
[CASMTRIAGE-7252](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7252) was opened because a CFS image customization session failed because the default IMS image size was too small. In an ideal world, this wouldn't happen because:
* CFS would try to get an idea of how big the image is, and specify an appropriate `build_env_size` to the IMS job that it creates.
or
* If no `build_env_size` was specified, IMS would try to determine a reasonable one based on the other parameters.

However, both of those are obviously more complicated things to implement. So this PR takes the safer route of just increasing our default IMS image size to a value that does not hit the problem in question.
