### PR TITLE
CASMTRIAGE-7401 - fix job pod anti-affinity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMTRIAGE-7401 - anti-affinity in the job pods.
 
 ## [3.19.0] - 2024-10-03
 

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -81,23 +81,26 @@ data:
       namespace: $namespace
     spec:
       backoffLimit: 0
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cray-ims
-            namespaces:
-              - $namespace
       template:
         metadata:
           labels:
             app: ims-$id-create
+            app.kubernetes.io/name: ims-job
         spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                        - ims-job
+                    namespaces:
+                      - $namespace
           runtimeClassName: $runtime_class
           serviceAccountName: $service_account
           restartPolicy: Never  # Don't ever restart this job

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -78,25 +78,28 @@ data:
       namespace: $namespace
     spec:
       backoffLimit: 0
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cray-ims
-            namespaces:
-              - $namespace
       template:
         metadata:
           annotations:
             io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o", "xattr"]'
           labels:
             app: ims-$id-customize
+            app.kubernetes.io/name: ims-job
         spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                        - ims-job
+                    namespaces:
+                      - $namespace
           runtimeClassName: $runtime_class
           serviceAccountName: $service_account
           restartPolicy: Never  # Don't ever restart this job


### PR DESCRIPTION
## Summary and Scope

The anti-affinity section was set up incorrectly. This resolved that issue.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7401](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7401)
* Change will also be needed in `node_images` repo

## Testing
### Tested on:

  * `starlord`

### Test description:

I installed the new version via helm and insured the anti-affinity is working correctly to spread out both build and customize jobs across all available worker nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

