### PR TITLE
CASMCMS-9166 - fix image delete/undelete preserving arch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9166 - fix image delete/undelete preserving arch setting.
 
 ## [3.20.0] - 2024-10-18
 ### Changed

--- a/src/server/v3/resources/images.py
+++ b/src/server/v3/resources/images.py
@@ -257,7 +257,8 @@ class V3ImageCollection(V3BaseImageResource):
                 # TODO ADD IMAGE FILTER OPTIONS
 
                 deleted_image = V3DeletedImageRecord(name=image.name, link=image.link,
-                                                     id=image.id, created=image.created)
+                                                     id=image.id, created=image.created,
+                                                     arch=image.arch)
                 if deleted_image.link:
                     try:
                         artifacts, _ = self._soft_delete_manifest_and_artifacts(log_id, image_id, image.link)
@@ -311,7 +312,8 @@ class V3ImageResource(V3BaseImageResource):
 
         try:
             image = current_app.data[self.images_table][image_id]
-            deleted_image = V3DeletedImageRecord(name=image.name, link=image.link, id=image.id, created=image.created)
+            deleted_image = V3DeletedImageRecord(name=image.name, link=image.link, id=image.id,
+                                                 arch=image.arch, created=image.created)
             if deleted_image.link:
                 try:
                     artifacts, _ = self._soft_delete_manifest_and_artifacts(log_id, image_id, image.link)
@@ -485,7 +487,8 @@ class V3DeletedImageCollection(V3BaseImageResource):
                 # TODO ADD IMAGE FILTER OPTIONS
 
                 image = V2ImageRecord(name=deleted_image.name, link=deleted_image.link,
-                                      id=deleted_image.id, created=deleted_image.created)
+                                      id=deleted_image.id, created=deleted_image.created,
+                                      arch=deleted_image.arch)
                 for key, value in list(json_data.items()):
                     if key == "operation":
                         if value == PATCH_OPERATION_UNDELETE:
@@ -596,7 +599,8 @@ class V3DeletedImageResource(V3BaseImageResource):
 
         deleted_image = current_app.data[self.deleted_images_table][deleted_image_id]
         image = V2ImageRecord(name=deleted_image.name, link=deleted_image.link,
-                              id=deleted_image.id, created=deleted_image.created)
+                              id=deleted_image.id, created=deleted_image.created,
+                              arch=deleted_image.arch)
         for key, value in list(json_data.items()):
             if key == "operation":
                 if value == PATCH_OPERATION_UNDELETE:


### PR DESCRIPTION
## Summary and Scope

When an image was deleted and a 'deleted image' object was created, it wasn't recording the arch of the image. This was making it always default to 'x86_64', so 'aarch64' images were being recorded 'x86_64' images.

This just pushes the correct value through the delete / undelete process.

## Issues and Related PRs
* Resolves [CASMCMS-9166](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9166)

## Testing
### Tested on:
  * `Mug`

### Test description:

I used Helm to install the test version on Mug and insured that delete/undelete now retains the correct 'arch' value throughout.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

