### PR TITLE
CASMCMS-9282: Bump Alpine version from 3.15 to 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.23.0] - 2025-02-13
 ### Dependencies
-- CASMCMS-9282: Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches
+- CASMCMS-9282
+  - Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches
+  - Move to `ims-utils` 2.16
 
 ## [3.22.0] - 2025-01-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.23.0] - 2025-02-13
+### Dependencies
+- CASMCMS-9282: Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches
 
 ## [3.22.0] - 2025-01-29
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018, 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018, 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 # Cray Image Management Service Dockerfile
 
 # Create 'base' image target
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 AS base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.21 AS base
 WORKDIR /app
 RUN mkdir -p /var/ims/data /app /results && \
     chown -Rv 65534:65534 /var/ims/data /app /results

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,6 +1,6 @@
 image: cray-ims-utils
     major: 2
-    minor: 15
+    minor: 16
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1


### PR DESCRIPTION
Alpine 3.15 no longer receives security patches.

I tested this on wasp and verifies it works.