### PR TITLE
CASMCMS-9363:IMS - deleted recipe always gets assigned arch=x86_64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9375: During create ims stores incorrect metadata for an image
+- CASMCMS-9363: IMS - deleted recipe always gets assigned arch=x86_64
 
 ## [3.23.0] - 2025-02-13
 ### Dependencies

--- a/src/server/v3/resources/recipes.py
+++ b/src/server/v3/resources/recipes.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -130,7 +130,8 @@ class V3RecipeCollection(V3BaseRecipeCollection):
                 deleted_recipe = V3DeletedRecipeRecord(name=recipe.name, recipe_type=recipe.recipe_type,
                                                        linux_distribution=recipe.linux_distribution,
                                                        template_dictionary=recipe.template_dictionary,
-                                                       id=recipe.id, created=recipe.created, link=recipe.link)
+                                                       id=recipe.id, created=recipe.created, link=recipe.link,
+                                                       arch=recipe.arch)
                 if deleted_recipe.link:
                     try:
                         deleted_recipe.link = soft_delete_artifact(recipe.link)
@@ -185,7 +186,8 @@ class V3RecipeResource(V3BaseRecipeCollection):
             deleted_recipe = V3DeletedRecipeRecord(name=recipe.name, recipe_type=recipe.recipe_type,
                                                    linux_distribution=recipe.linux_distribution,
                                                    template_dictionary=recipe.template_dictionary,
-                                                   id=recipe.id, created=recipe.created, link=recipe.link)
+                                                   id=recipe.id, created=recipe.created, link=recipe.link,
+                                                   arch=recipe.arch)
             if deleted_recipe.link:
                 try:
                     deleted_recipe.link = soft_delete_artifact(recipe.link)
@@ -339,7 +341,7 @@ class V3DeletedRecipeCollection(V3BaseRecipeCollection):
                                         linux_distribution=deleted_recipe.linux_distribution,
                                         template_dictionary=deleted_recipe.template_dictionary,
                                         id=deleted_recipe.id, created=deleted_recipe.created,
-                                        link=deleted_recipe.link)
+                                        link=deleted_recipe.link, arch=deleted_recipe.arch)
                 for key, value in list(json_data.items()):
                     if key == "operation":
                         if value == PATCH_OPERATION_UNDELETE:
@@ -438,7 +440,7 @@ class V3DeletedRecipeResource(V3BaseRecipeCollection):
                                 linux_distribution=deleted_recipe.linux_distribution,
                                 template_dictionary=deleted_recipe.template_dictionary,
                                 id=deleted_recipe.id, created=deleted_recipe.created,
-                                link=deleted_recipe.link)
+                                link=deleted_recipe.link, arch=deleted_recipe.arch)
         for key, value in list(json_data.items()):
             if key == "operation":
                 if value == PATCH_OPERATION_UNDELETE:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMCMS-9363:IMS - deleted recipe always gets assigned arch=x86_64

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta
Tested on mug

Here is test result

```
ncn-m001:~/rahul/repo/ims # cray ims recipes create --name "fake-recipe-name" --linux-distribution sles15 --recipe-type kiwi-ng -vvv
Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.crayadmin
REQUEST: POST to https://api-gw-service-nmn.local/apis/ims/v3/recipes
OPTIONS: {'json': {'recipe_type': 'kiwi-ng', 'linux_distribution': 'sles15', 'name': 'fake-recipe-name'}, 'verify': False}
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
linux_distribution = "sles15"
template_dictionary = []
require_dkms = true
arch = "x86_64"
id = "93fe1d45-02d7-4d76-8b8a-5c91d78131e8"
created = "2025-04-23T16:52:54.731008"

=====
update
=====
ncn-m001:~/rahul/repo/ims # cray ims recipes update 93fe1d45-02d7-4d76-8b8a-5c91d78131e8 --arch aarch64 -vvv
Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.crayadmin
REQUEST: PATCH to https://api-gw-service-nmn.local/apis/ims/v3/recipes/93fe1d45-02d7-4d76-8b8a-5c91d78131e8
OPTIONS: {'json': {'arch': 'aarch64'}, 'verify': False}
arch = "aarch64"
created = "2025-04-23T16:52:54.731008"
id = "93fe1d45-02d7-4d76-8b8a-5c91d78131e8"
linux_distribution = "sles15"
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
require_dkms = true
template_dictionary = []

======
Describe
======
ncn-m001:~/rahul/repo/ims # cray ims deleted recipes describe 93fe1d45-02d7-4d76-8b8a-5c91d78131e8
arch = "aarch64"
created = "2025-04-23T16:52:54.731008"
deleted = "2025-04-23T16:53:37.295145"
id = "93fe1d45-02d7-4d76-8b8a-5c91d78131e8"
linux_distribution = "sles15"
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
require_dkms = true
template_dictionary = []

=======
Restore & Describe
=======

ncn-m001:~/rahul/repo/ims # cray ims deleted recipes update 93fe1d45-02d7-4d76-8b8a-5c91d78131e8 --operation undelete

ncn-m001:~/rahul/repo/ims # cray ims recipes describe 93fe1d45-02d7-4d76-8b8a-5c91d78131e8
arch = "aarch64"
created = "2025-04-23T16:52:54.731008"
id = "93fe1d45-02d7-4d76-8b8a-5c91d78131e8"
linux_distribution = "sles15"
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
require_dkms = true
template_dictionary = []

======
Perm Delete
======
ncn-m001:~/rahul/repo/ims # cray ims recipes delete 93fe1d45-02d7-4d76-8b8a-5c91d78131e8

ncn-m001:~/rahul/repo/ims # cray ims deleted recipes delete 93fe1d45-02d7-4d76-8b8a-5c91d78131e8

ncn-m001:~/rahul/repo/ims # cray ims recipes describe 93fe1d45-02d7-4d76-8b8a-5c91d78131e8
Usage: cray ims recipes describe [OPTIONS] RECIPE_ID
Try 'cray ims recipes describe -h' for help.

Error: Not Found: Requested resource does not exist. Re-run request with valid ID.
ncn-m001:~/rahul/repo/ims # cray ims deleted recipes describe 93fe1d45-02d7-4d76-8b8a-5c91d78131e8
Usage: cray ims deleted recipes describe [OPTIONS] RECIPE_ID
Try 'cray ims deleted recipes describe -h' for help.

Error: Not Found: Requested resource does not exist. Re-run request with valid ID.

```
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

