### PR TITLE
CASMCMS-9389: Soft delete/restore Persisting the metadata of an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9387: API V2: During create image ims stores incorrect metadata for an image
+- CASMCMS-9389: IMS image tags removed by soft delete
 
 ## [3.24.1] - 2025-04-25
 ### Fixed

--- a/src/server/v2/resources/images.py
+++ b/src/server/v2/resources/images.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/server/v3/resources/images.py
+++ b/src/server/v3/resources/images.py
@@ -267,7 +267,7 @@ class V3ImageCollection(V3BaseImageResource):
 
                 deleted_image = V3DeletedImageRecord(name=image.name, link=image.link,
                                                      id=image.id, created=image.created,
-                                                     arch=image.arch)
+                                                     arch=image.arch, metadata=image.metadata)
                 if deleted_image.link:
                     try:
                         artifacts, _ = self._soft_delete_manifest_and_artifacts(log_id, image_id, image.link)
@@ -322,7 +322,7 @@ class V3ImageResource(V3BaseImageResource):
         try:
             image = current_app.data[self.images_table][image_id]
             deleted_image = V3DeletedImageRecord(name=image.name, link=image.link, id=image.id,
-                                                 arch=image.arch, created=image.created)
+                                                 arch=image.arch, created=image.created, metadata=image.metadata)
             if deleted_image.link:
                 try:
                     artifacts, _ = self._soft_delete_manifest_and_artifacts(log_id, image_id, image.link)
@@ -497,7 +497,7 @@ class V3DeletedImageCollection(V3BaseImageResource):
 
                 image = V2ImageRecord(name=deleted_image.name, link=deleted_image.link,
                                       id=deleted_image.id, created=deleted_image.created,
-                                      arch=deleted_image.arch)
+                                      arch=deleted_image.arch, metadata=deleted_image.metadata)
                 for key, value in list(json_data.items()):
                     if key == "operation":
                         if value == PATCH_OPERATION_UNDELETE:
@@ -609,7 +609,7 @@ class V3DeletedImageResource(V3BaseImageResource):
         deleted_image = current_app.data[self.deleted_images_table][deleted_image_id]
         image = V2ImageRecord(name=deleted_image.name, link=deleted_image.link,
                               id=deleted_image.id, created=deleted_image.created,
-                              arch=deleted_image.arch)
+                              arch=deleted_image.arch, metadata=deleted_image.metadata)
         for key, value in list(json_data.items()):
             if key == "operation":
                 if value == PATCH_OPERATION_UNDELETE:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMCMS-9389: Soft delete/restore Persisting the metadata of an image

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

tested on mug

```
ncn-m001:~/rahul/repo/ims # cray ims images create --name fakeimagetest --metadata-key name --metadata-value fakeimagetest -vvv
Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.crayadmin
REQUEST: POST to https://api-gw-service-nmn.local/apis/ims/v3/images
OPTIONS: {'json': {'name': 'fakeimagetest', 'metadata': {'key': 'name', 'value': 'fakeimagetest'}}, 'verify': False}
name = "fakeimagetest"
arch = "x86_64"
id = "dff61533-c05c-466d-b0e4-160212efc425"
created = "2025-04-28T15:08:47.496447"

[metadata]
name = "fakeimagetest"

ncn-m001:~/rahul/repo/ims # cray ims images delete dff61533-c05c-466d-b0e4-160212efc425

ncn-m001:~/rahul/repo/ims # cray ims deleted images describe dff61533-c05c-466d-b0e4-160212efc425
arch = "x86_64"
created = "2025-04-28T15:08:47.496447"
deleted = "2025-04-28T15:09:08.800043"
id = "dff61533-c05c-466d-b0e4-160212efc425"
name = "fakeimagetest"

[metadata]
name = "fakeimagetest"

ncn-m001:~/rahul/repo/ims # cray ims deleted images update dff61533-c05c-466d-b0e4-160212efc425 --operation undelete

ncn-m001:~/rahul/repo/ims # cray ims images describe dff61533-c05c-466d-b0e4-160212efc425
arch = "x86_64"
created = "2025-04-28T15:08:47.496447"
id = "dff61533-c05c-466d-b0e4-160212efc425"
name = "fakeimagetest"

[metadata]
name = "fakeimagetest"

```

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

