### PR TITLE
CASMCMS-9396: Persist require_dkms during soft delete/restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - CASMCMS-9387: API V2: During create image ims stores incorrect metadata for an image
 - CASMCMS-9389: IMS image tags removed by soft delete
+- CASMCMS-9396: IMS - deleted recipe always gets assigned require_dkms=true
 
 ## [3.24.1] - 2025-04-25
 ### Fixed

--- a/src/server/v3/resources/recipes.py
+++ b/src/server/v3/resources/recipes.py
@@ -131,7 +131,7 @@ class V3RecipeCollection(V3BaseRecipeCollection):
                                                        linux_distribution=recipe.linux_distribution,
                                                        template_dictionary=recipe.template_dictionary,
                                                        id=recipe.id, created=recipe.created, link=recipe.link,
-                                                       arch=recipe.arch)
+                                                       arch=recipe.arch, require_dkms=recipe.require_dkms)
                 if deleted_recipe.link:
                     try:
                         deleted_recipe.link = soft_delete_artifact(recipe.link)
@@ -187,7 +187,7 @@ class V3RecipeResource(V3BaseRecipeCollection):
                                                    linux_distribution=recipe.linux_distribution,
                                                    template_dictionary=recipe.template_dictionary,
                                                    id=recipe.id, created=recipe.created, link=recipe.link,
-                                                   arch=recipe.arch)
+                                                   arch=recipe.arch, require_dkms=recipe.require_dkms)
             if deleted_recipe.link:
                 try:
                     deleted_recipe.link = soft_delete_artifact(recipe.link)
@@ -341,7 +341,8 @@ class V3DeletedRecipeCollection(V3BaseRecipeCollection):
                                         linux_distribution=deleted_recipe.linux_distribution,
                                         template_dictionary=deleted_recipe.template_dictionary,
                                         id=deleted_recipe.id, created=deleted_recipe.created,
-                                        link=deleted_recipe.link, arch=deleted_recipe.arch)
+                                        link=deleted_recipe.link, arch=deleted_recipe.arch,
+                                        require_dkms=deleted_recipe.require_dkms)
                 for key, value in list(json_data.items()):
                     if key == "operation":
                         if value == PATCH_OPERATION_UNDELETE:
@@ -440,7 +441,8 @@ class V3DeletedRecipeResource(V3BaseRecipeCollection):
                                 linux_distribution=deleted_recipe.linux_distribution,
                                 template_dictionary=deleted_recipe.template_dictionary,
                                 id=deleted_recipe.id, created=deleted_recipe.created,
-                                link=deleted_recipe.link, arch=deleted_recipe.arch)
+                                link=deleted_recipe.link, arch=deleted_recipe.arch,
+                                require_dkms=deleted_recipe.require_dkms)
         for key, value in list(json_data.items()):
             if key == "operation":
                 if value == PATCH_OPERATION_UNDELETE:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMCMS-9396: Persist require_dkms during soft delete/restore

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta
Tested on mug

```
ncn-m001:~ # cray ims recipes create --name "fake-recipe-name" --linux-distribution sles15 --recipe-type kiwi-ng --require-dkms false --template-dictionary-key USS_VERSION,FULL_COS_BASE_VERSION --template-dictionary-value "1.1.2-1-cos-base","3.1.2-1-sle-15.5" -vvv
Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.crayadmin
REQUEST: POST to https://api-gw-service-nmn.local/apis/ims/v3/recipes
OPTIONS: {'json': {'recipe_type': 'kiwi-ng', 'linux_distribution': 'sles15', 'name': 'fake-recipe-name', 'require_dkms': False, 'template_dictionary': [{'key': 'USS_VERSION', 'value': '1.1.2-1-cos-base'}, {'key': 'FULL_COS_BASE_VERSION', 'value': '3.1.2-1-sle-15.5'}]}, 'verify': False}
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
linux_distribution = "sles15"
require_dkms = false
arch = "x86_64"
id = "d2b35a20-bdea-4bb0-96f3-97852e90716a"
created = "2025-04-28T23:08:08.714477"
[[template_dictionary]]
key = "USS_VERSION"
value = "1.1.2-1-cos-base"

[[template_dictionary]]
key = "FULL_COS_BASE_VERSION"
value = "3.1.2-1-sle-15.5"


ncn-m001:~ # cray ims recipes delete d2b35a20-bdea-4bb0-96f3-97852e90716a

ncn-m001:~ # cray ims deleted recipes describe d2b35a20-bdea-4bb0-96f3-97852e90716a
arch = "x86_64"
created = "2025-04-28T23:08:08.714477"
deleted = "2025-04-28T23:08:27.473385"
id = "d2b35a20-bdea-4bb0-96f3-97852e90716a"
linux_distribution = "sles15"
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
require_dkms = false
[[template_dictionary]]
key = "USS_VERSION"
value = "1.1.2-1-cos-base"

[[template_dictionary]]
key = "FULL_COS_BASE_VERSION"
value = "3.1.2-1-sle-15.5"


ncn-m001:~ # cray ims deleted recipes update d2b35a20-bdea-4bb0-96f3-97852e90716a --operation undelete

ncn-m001:~ # cray ims recipes describe d2b35a20-bdea-4bb0-96f3-97852e90716a
arch = "x86_64"
created = "2025-04-28T23:08:08.714477"
id = "d2b35a20-bdea-4bb0-96f3-97852e90716a"
linux_distribution = "sles15"
name = "fake-recipe-name"
recipe_type = "kiwi-ng"
require_dkms = false
[[template_dictionary]]
key = "USS_VERSION"
value = "1.1.2-1-cos-base"

[[template_dictionary]]
key = "FULL_COS_BASE_VERSION"
value = "3.1.2-1-sle-15.5"
```
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

