### PR TITLE
CASMCMS-9408:Conditionalize podsecuritypolicies references in cray-ims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims
+
 ## [3.24.2] - 2025-04-29
 ### Fixed
 - CASMCMS-9387: API V2: During create image ims stores incorrect metadata for an image

--- a/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -42,6 +42,7 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "create", "delete", "patch"]
+  {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
   - apiGroups:
     - policy
     resourceNames:
@@ -50,6 +51,7 @@ rules:
     - podsecuritypolicies
     verbs:
     - use
+  {{- end}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMCMS-9408:Conditionalize podsecuritypolicies references in cray-ims

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta
Successfully deployed ims service 

here is deployed cluster role
```
ncn-m001:~/rahul/repo/ims # kubectl describe clusterrole ims-service-launch-job -n services
Name:         ims-service-launch-job
Labels:       app.kubernetes.io/managed-by=Helm
Annotations:  meta.helm.sh/release-name: cray-ims
              meta.helm.sh/release-namespace: services
PolicyRule:
  Resources                             Non-Resource URLs  Resource Names  Verbs
  ---------                             -----------------  --------------  -----
  jobs.batch                            []                 []              [get create delete patch]
  configmaps                            []                 []              [get create delete]
  persistentvolumeclaims                []                 []              [get create delete]
  roles                                 []                 []              [get create delete]
  secrets                               []                 []              [get create delete]
  services                              []                 []              [get create delete]
  destinationrules.networking.istio.io  []                 []              [get create delete]
  podsecuritypolicies.policy            []                 [privileged]    [use]
ncn-m001:~/rahul/repo/ims # kubectl get clusterrole ims-service-launch-job -n services -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    meta.helm.sh/release-name: cray-ims
    meta.helm.sh/release-namespace: services
  creationTimestamp: "2024-07-18T19:45:19Z"
  labels:
    app.kubernetes.io/managed-by: Helm
  name: ims-service-launch-job
  resourceVersion: "72041"
  uid: 17a07a05-d571-44ca-b5d5-b2fc3e096091
rules:
- apiGroups:
  - ""
  resources:
  - services
  - configmaps
  - roles
  - persistentvolumeclaims
  - secrets
  verbs:
  - get
  - create
  - delete
- apiGroups:
  - networking.istio.io
  resources:
  - destinationrules
  verbs:
  - get
  - create
  - delete
- apiGroups:
  - batch
  resources:
  - jobs
  verbs:
  - get
  - create
  - delete
  - patch
- apiGroups:
  - policy
  resourceNames:
  - privileged
  resources:
  - podsecuritypolicies
  verbs:
  - use
```

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

