### PR TITLE
CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.2] - 2025-04-29
 ### Fixed
 - CASMCMS-9387: API V2: During create image ims stores incorrect metadata for an image
 - CASMCMS-9389: IMS image tags removed by soft delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims
+
 ## [3.24.2] - 2025-04-29
 ### Fixed
 - CASMCMS-9387: API V2: During create image ims stores incorrect metadata for an image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.3] - 2025-05-14
 ### Fixed
 CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims
 

--- a/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -42,6 +42,7 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "create", "delete", "patch"]
+  {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
   - apiGroups:
     - policy
     resourceNames:
@@ -50,6 +51,7 @@ rules:
     - podsecuritypolicies
     verbs:
     - use
+  {{- end}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims

cray-ims chart (3.23.0) has references to podsecuritypolicies that needs to be conditionalized for deployment on CSM 1.7.