### PR TITLE
CASMCMS-9399 - update dependencies for CVE issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9399 - update gunicorn to v23.0.0 for CVE issue
+| Package         | From     | To       |
+|-----------------|----------|----------|
+| `certifi`       | 2024.2.2 | 2024.7.4 |
+| `gunicorn`      | 22.0.0   | 23.0.0   |
+| `Jinja2`        | 3.1.4    | 3.1.6    |
+| `requests`      | 2.31.0   | 2.32.2   |
+| `urllib3`       | 1.26.18  | 1.26.19  |
+| `Werkzeug`      | 3.0.3    | 3.0.6    |
+
 ## [3.24.3] - 2025-05-14
 ### Fixed
 CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,7 @@ aniso8601==9.0.1
 boto3==1.36.2
 botocore==1.36.2
 cachetools==5.3.3
-certifi==2024.2.2
+certifi==2024.7.4
 chardet==5.2.0
 click==8.1.7
 docutils==0.21.2
@@ -12,11 +12,11 @@ Flask==3.0.3
 flask-marshmallow==1.2.1
 Flask-RESTful==0.3.10
 google-auth==2.29.0
-gunicorn==22.0.0
+gunicorn==23.0.0
 httpproblem==0.2.0
 idna==3.7
 itsdangerous==2.2.0
-Jinja2==3.1.4
+Jinja2==3.1.6
 jmespath==1.0.1
 # CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility
 kubernetes>=24.2,<24.3
@@ -29,11 +29,11 @@ python-dateutil==2.8.2
 pytest==8.1.1
 pytz==2024.1
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.2
 requests-oauthlib==1.3.1
 rsa==4.9
 s3transfer==0.11.1
 setuptools >= 70.0
-urllib3==1.26.18 # most recent 2.2.1, botocore 1.34.114 requires <1.27.0
+urllib3==1.26.19 # most recent 2.2.1, botocore 1.34.114 requires <1.27.0
 websocket-client==1.8.0
-Werkzeug==3.0.3
+Werkzeug==3.0.6


### PR DESCRIPTION
## Summary and Scope

Several python modules needed to be upgraded due to CVE issues.

## Issues and Related PRs
* Resolves [CASMCMS-9399](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9399)

## Testing
### Tested on:

  * `Mug`

### Test description:

I upgraded the ims service via helm to the new version, then did manual testing and ran the cmsdev ims tests to verify the entire api works correctly. The major upgrade was in gunicorn, so verifying the api works checked most of what changed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - minor patch updates for several python modules.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

