### PR TITLE
CASMCMS-9451 - fix pod level security context and cray-service version for ceph upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9451 - add pod level security context so PVC's are mounted with the correct owner.
+
+### Dependencies
+- Bumped cray-services base chart minimum version to 12.0.0
+
 ## [3.25.0] - 2025-05-29
 ### Dependencies
 - CASMCMS-9399 - update gunicorn to v23.0.0 for CVE issue

--- a/kubernetes/cray-ims/Chart.yaml
+++ b/kubernetes/cray-ims/Chart.yaml
@@ -36,13 +36,11 @@ sources:
 - https://github.com/Cray-HPE/ims-sshd
 dependencies:
 - name: cray-service
-  version: ^11.0.0
+  version: ^12.0.0
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
 - name: dlaine-hpe
   email: laine@hpe.com
-- name: juliansmit-hpe
-  email: julian.smit@hpe.com
 - name: mharding-hpe
   email: mitchell.harding@hpe.com
 appVersion: 0.0.0-imsserv-docker

--- a/kubernetes/cray-ims/values.yaml
+++ b/kubernetes/cray-ims/values.yaml
@@ -95,7 +95,10 @@ jobs:
 cray-service:
   type: Deployment
   nameOverride: cray-ims
-
+  securityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
   containers:
     cray-ims:
       name: cray-ims


### PR DESCRIPTION
## Summary and Scope

The data directory created on a PVC mount through ceph is getting the wrong owner/permissions setup with the new ceph upgrade installed. This change sets up the user and fsGroup in the container level of the helm chart so that when a new volume is created, it will have the correct permissions so that the ims service can write files to the data dir.

## Issues and Related PRs
* Resolves [CASMCMS-9451](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9451)

## Testing
### Tested on:
  * `Mug`
  * Virtual Shasta - scanlon

### Test description:

I uninstalled the current version of ims that was installed on the system, then did a clean 'helm install' with the new version. I then confirmed that the /var/ims/data directory is created with the correct owner/permissions so that the IMS service could write to the dir and work correctly.

NOTE: I only observed this behavior on a new vshasta system with the upgraded version of ceph and k8s present. With the hardware systems I tested, the old ownership was still seen but that has older version of ceph and k8s installed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Medium risk as these are changes for a configuration that isn't present on a physical system.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

