### PR TITLE
CASMCMS-9452:Cleanup of leftover Cluster/RoleBindings under CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9452: Cleanup of leftover Cluster/RoleBindings under CMS
+
 ## [3.26.0] - 2025-06-04
 ### Fixed
 - CASMCMS-9451 - add pod level security context so PVC's are mounted with the correct owner.

--- a/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-rbac.yaml
@@ -72,6 +72,7 @@ metadata:
   name: ims-service-job-mount
   namespace: {{ .Values.ims_config.cray_ims_job_namespace }}
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -84,3 +85,4 @@ roleRef:
   kind: ClusterRole
   name: privileged-psp
   apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9452: Cleanup of leftover Cluster/RoleBindings under CMS

## Testing
Deployed the service on mug

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

