### PR TITLE
CASMCMS-8923: updated cray-ims-kiwi-ng-opensuse-x86_64-builder to 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+CASMCMS-8923: Updated `cray-ims-kiwi-ng-opensuse-x86_64-builder` version to `1.9`
+
 ## [3.24.3] - 2025-05-14
 ### Fixed
 CASMCMS-9408: Conditionalize podsecuritypolicies references in cray-ims

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -4,7 +4,7 @@ image: cray-ims-utils
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
-    minor: 8
+    minor: 9
 
 image: cray-ims-sshd
     major: 1


### PR DESCRIPTION
## Summary and Scope

CASMCMS-8923: updated cray-ims-kiwi-ng-opensuse-x86_64-builder to 1.9

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

