### PR TITLE
CASMCMS-8939 - better port forwarding for remote jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Updated
-CASMCMS-8923: Updated `cray-ims-kiwi-ng-opensuse-x86_64-builder` version to `1.9`
+- CASMCMS-8923 - Updated `cray-ims-kiwi-ng-opensuse-x86_64-builder` version to `1.9`
+- CASMCMS-8939 - better port forwarding for remote jobs.
 
 ## [3.27.0] - 2025-06-05
 ### Fixed

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-NOTE: Kata hypevisor setup adds ALL container cpu limits together for
+NOTE: Kata hypervisor setup adds ALL container cpu limits together for
   the hardware description.  This changes the nproc return of available
   cpus in the container, possibly overloading the VM causing it to
   crash. Be careful adjusting any cpu limits for the containers.
@@ -142,6 +142,9 @@ data:
               readOnly: true
             - name: remote-key
               mountPath: /etc/cray/remote-keys
+              readOnly: true
+            - name: ssh-pubkey
+              mountPath: /etc/cray
               readOnly: true
             command: [ "sh", "-ce", "/scripts/prep-env.sh /mnt/image \"$download_url\"" ]
             resources:

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,6 +1,6 @@
 image: cray-ims-utils
     major: 2
-    minor: 16
+    minor: 17
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
@@ -8,4 +8,4 @@ image: cray-ims-kiwi-ng-opensuse-x86_64-builder
 
 image: cray-ims-sshd
     major: 1
-    minor: 12
+    minor: 13


### PR DESCRIPTION
## Summary and Scope

Use port-forwarding via iptables to forward ssh connections to a remote build node rather than routing through an ssh server. This is much more straightforward and allows commands like scp and sftp to work as well as the basic ssh commands.

## Issues and Related PRs
* Resolves [CASMCMS-8939](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8939)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new set of images and helm charts via loftsman and ran both manual and cfs image customization jobs. I verified that the jobs worked as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is low risk - it only applies to remote image customization jobs.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable