### PR TITLE
CASMCMS-9455: Updated ims-utils version to 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+- CASMCMS-8022: Updated `ims-utils` version to `2.18` and `kiwi-ng` version to `1.10`
+
 ## [3.28.0] - 2025-06-11
 ### Updated
 - CASMCMS-8923 - Updated `cray-ims-kiwi-ng-opensuse-x86_64-builder` version to `1.9`

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,10 +1,10 @@
 image: cray-ims-utils
     major: 2
-    minor: 17
+    minor: 18
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
-    minor: 9
+    minor: 10
 
 image: cray-ims-sshd
     major: 1


### PR DESCRIPTION
## Summary and Scope
CASMCMS-9455: Updated ims-utils version to 2.18
This IMS utils version has fix for following JIRA
- CASMCMS-9455: Building image from recipe Job stuck at waiting_for_repos status
- CASMCMS-9364: Confirm exposed SSH private key impact in ims-python-helper

- CASMCMS-8022: It also contains python module updates for `ims-python-helper` and -ims-utils`


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

