### PR TITLE
develop->master CASMCMS-8022: Updated `ims-utils` version to `2.18` and `kiwi-ng` version to `1.10`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.29.0] - 2025-06-25
 ### Updated
 - CASMCMS-8022: Updated `ims-utils` version to `2.18` and `kiwi-ng` version to `1.10`
 


### PR DESCRIPTION
## Summary and Scope

CASMCMS-8022: Updated `ims-utils` version to `2.18` and `kiwi-ng` version to `1.10`

This `ims-utils` and `kiwi-ng` version has fix for following JIRA

CASMCMS-9455: Building image from recipe Job stuck at waiting_for_repos status

CASMCMS-9364: Confirm exposed SSH private key impact in ims-python-helper

CASMCMS-8022: It also contains python module updates for ims-python-helper and -ims-utils`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

