### PR TITLE
CASMCMS-9510: Added LOG_LEVEL ENV in build image and customize image configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9510: Added `LOG_LEVEL` ENV in `build image` and `customize image` configmap.
+
 ### Dependencies
 - Updated `kubernetes` module to match CSM 1.7 version
+- CASMCMS-9510: Updated `ims-utils` version to `2.19.x` and `ims-kiwi-ng-opensuse-x86_64-builder` to `1.12.X`
 
 ## [3.30.0] - 2025-06-25
 ### Changed

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -120,6 +120,8 @@ data:
               value: "$id"
             - name: DOWNLOAD_MD5SUM
               value: "$download_md5sum"
+            - name: LOG_LEVEL
+              value: "INFO"
             envFrom:
             - configMapRef:
                 name: cray-ims-$id-configmap
@@ -156,6 +158,8 @@ data:
               value: "$id"
             - name: OAUTH_CONFIG_DIR
               value: '/etc/admin-client-auth'
+            - name: LOG_LEVEL
+              value: "INFO"
             volumeMounts:
             - name: image-vol
               mountPath: /mnt/image
@@ -188,6 +192,8 @@ data:
               value: "$id"
             - name: BUILD_ARCH
               value: "$job_arch"
+            - name: LOG_LEVEL
+              value: "INFO"
             volumeMounts:
             - name: ca-rpm-vol
               mountPath: /mnt/ca-rpm
@@ -314,6 +320,8 @@ data:
               value: "$job_arch"
             - name: S3_BUCKET
               value: "$s3_bucket"
+            - name: LOG_LEVEL
+              value: "INFO"
             - name: S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -131,6 +131,8 @@ data:
               value: /mnt/image
             - name: IMS_SSHD_IMAGE
               value: {{ .Values.cray_ims_sshd.image.repository }}:{{ .Values.cray_ims_sshd.image.tag }}
+            - name: LOG_LEVEL
+              value: "INFO"
             volumeMounts:
             - name: image-vol
               mountPath: /mnt/image
@@ -204,6 +206,8 @@ data:
               value: '$remote_build_node'
             - name: S3_BUCKET
               value: "$s3_bucket"
+            - name: LOG_LEVEL
+              value: "INFO"
             - name: S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,10 +1,10 @@
 image: cray-ims-utils
     major: 2
-    minor: 18
+    minor: 19
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
-    minor: 11
+    minor: 12
 
 image: cray-ims-sshd
     major: 1


### PR DESCRIPTION
## Summary and Scope
CASMCMS-9510: Added LOG_LEVEL ENV in build image and customize image configmap
The change adds the flexibility to the users to change logging level during `build image` and `customize image`. 

## Testing
This was tested on `mug`. Following tests were run for `build image` and `customize image`
> `LOG_LEVEL` ENV set to `INFO` 
> `LOG_LEVEL` ENV set to `WARNING`
> `LOG_LEVEL` ENV set to `DEBUG`
> Remove `LOG_LEVEL` ENV variable  from build image` and `customize image` configmap.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

