### PR TITLE
CASMCMS-8904 - remote build optimizations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- CASMCMS-8904 - optimize remote node builds.
 
 ### Dependencies
 - Updated `kubernetes` module to match CSM 1.7 version

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-create-kiwi-ng-job-template.yaml
@@ -248,8 +248,12 @@ data:
               value: "{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.repository }}:{{ .Values.cray_ims_kiwi_ng_opensuse_x86_64_builder.image.tag }}"
             - name: IMAGE_ROOT_ARCHIVE_NAME
               value: "$image_root_archive_name"
+            - name: KERNEL_FILENAME
+              value: $kernel_filename
             - name: INITRD_FILENAME
-              value: "$initrd_filename"
+              value: $initrd_filename
+            - name: KERNEL_PARAMETERS_FILENAME
+              value: $kernel_parameters_filename
             volumeMounts:
             - name: image-vol
               mountPath: /mnt/image

--- a/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
+++ b/kubernetes/cray-ims/templates/cray-ims-v2-image-customize-job-template.yaml
@@ -131,6 +131,12 @@ data:
               value: /mnt/image
             - name: IMS_SSHD_IMAGE
               value: {{ .Values.cray_ims_sshd.image.repository }}:{{ .Values.cray_ims_sshd.image.tag }}
+            - name: KERNEL_FILENAME
+              value: $kernel_filename
+            - name: INITRD_FILENAME
+              value: $initrd_filename
+            - name: KERNEL_PARAMETERS_FILENAME
+              value: $kernel_parameters_filename
             volumeMounts:
             - name: image-vol
               mountPath: /mnt/image

--- a/src/server/v2/resources/jobs.py
+++ b/src/server/v2/resources/jobs.py
@@ -289,10 +289,10 @@ class V2BaseJobResource(Resource):
 
         resources = OrderedDict()
         resources['service'] = k8s_v1api.delete_namespaced_service
+        resources['pvc'] = k8s_v1api.delete_namespaced_persistent_volume_claim
         if delete_job:
             resources['job'] = k8s_batchv1api.delete_namespaced_job
             resources['configmap'] = k8s_v1api.delete_namespaced_config_map
-            resources['pvc'] = k8s_v1api.delete_namespaced_persistent_volume_claim
             resources['secret'] = k8s_v1api.delete_namespaced_secret
 
         # Delete the underlying kubernetes service, job and configmap resources

--- a/src/server/v3/resources/jobs.py
+++ b/src/server/v3/resources/jobs.py
@@ -288,11 +288,11 @@ class V3BaseJobResource(Resource):
         k8s_delete_options.propagation_policy = "Background"
 
         resources = OrderedDict()
+        resources['pvc'] = k8s_v1api.delete_namespaced_persistent_volume_claim
         resources['service'] = k8s_v1api.delete_namespaced_service
         if delete_job:
             resources['job'] = k8s_batchv1api.delete_namespaced_job
             resources['configmap'] = k8s_v1api.delete_namespaced_config_map
-            resources['pvc'] = k8s_v1api.delete_namespaced_persistent_volume_claim
             resources['secret'] = k8s_v1api.delete_namespaced_secret
 
         # Delete the underlying kubernetes resources

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,11 +1,11 @@
 image: cray-ims-utils
     major: 2
-    minor: 18
+    minor: 20
 
 image: cray-ims-kiwi-ng-opensuse-x86_64-builder
     major: 1
-    minor: 11
+    minor: 13
 
 image: cray-ims-sshd
     major: 1
-    minor: 13
+    minor: 14


### PR DESCRIPTION
## Summary and Scope

Make changes to the remote build process to minimize extra work copying and squashing/unsquashing the image. This pushes more work to happen on the remote node so that once the image file is transferred back to the job pod it no longer needs further modification.

This also makes a small change to delete PVC resources when the job is complete. These volumes can be large and once the pod has finished they are not really useful. The other resources are kept for debugging purposes.

This requires changes in:
ims
ims-utils
ims-sshd
ims-kiwi-ng-opensuse-x86_64-builder

## Issues and Related PRs
* Resolves [CASMCMS-8904](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8904)

## Testing
### Tested on:
  * `Mug`, and `Odin`

### Test description:

Installed the changes on the system and built complete images (from uss recipe, including shs, cos, gpu, sma, etc products) both remotely and locally and verified they booted and configured correctly. This was done with both x86 and aarch64 images. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change, but has been pretty thoroughly tested.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

